### PR TITLE
Fixed the beCloseTo macro and object to do a more-correct float comparison.

### DIFF
--- a/src/matchers/EXPMatchers+beCloseTo.h
+++ b/src/matchers/EXPMatchers+beCloseTo.h
@@ -3,5 +3,5 @@
 EXPMatcherInterface(_beCloseToWithin, (id expected, id within));
 EXPMatcherInterface(beCloseToWithin, (id expected, id within));
 
-#define beCloseTo(expected) _beCloseToWithin(EXPObjectify((expected)), EXPObjectify(0.1))
+#define beCloseTo(expected) _beCloseToWithin(EXPObjectify((expected)), nil)
 #define beCloseToWithin(expected, range) _beCloseToWithin(EXPObjectify((expected)), EXPObjectify((range)))

--- a/src/matchers/EXPMatchers+beCloseTo.m
+++ b/src/matchers/EXPMatchers+beCloseTo.m
@@ -5,16 +5,25 @@ EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
     prerequisite(^BOOL{
         return [actual isKindOfClass:[NSNumber class]] &&
 		[expected isKindOfClass:[NSNumber class]] &&
-		[within isKindOfClass:[NSNumber class]];
+		([within isKindOfClass:[NSNumber class]] || (within == nil));
     });
 
     match(^BOOL{
-        double actualValue = [actual doubleValue];
-        double expectedValue = [expected doubleValue];
-        double withinValue = [within doubleValue];
-        double lowerBound = expectedValue - withinValue;
-        double upperBound = expectedValue + withinValue;
-        return (actualValue > lowerBound) && (actualValue < upperBound);
+		double actualValue = [actual doubleValue];
+		double expectedValue = [expected doubleValue];
+		
+		if (within != nil) {
+			double withinValue = [within doubleValue];
+			double lowerBound = expectedValue - withinValue;
+			double upperBound = expectedValue + withinValue;
+			return (actualValue > lowerBound) && (actualValue < upperBound);
+		} else {
+			double diff = fabs(actualValue - expectedValue);
+			actualValue = fabs(actualValue);
+			expectedValue = fabs(expectedValue);
+			double largest = (expectedValue > actualValue) ? expectedValue : actualValue;
+			return (diff <= largest * FLT_EPSILON);
+		}
     });
 
     failureMessageForTo(^NSString *{


### PR DESCRIPTION
Came from reading this really good article on float comparison: http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
