### PR TITLE
Fixes crash when passing a block to expect()

### DIFF
--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -53,14 +53,17 @@ id _EXPObjectify(char *type, ...) {
   } else if(strcmp(type, @encode(unsigned short)) == 0) {
     unsigned short actual = (unsigned short)va_arg(v, unsigned int);
     obj = [NSNumber numberWithUnsignedShort:actual];
+  } else if(strstr(type, @encode(EXPBasicBlock)) != NULL) {
+      // @encode(EXPBasicBlock) returns @? as of clang 4.1.
+      // This condition must occur before the test for id/class type,
+      // otherwise blocks will be treated as vanilla objects.
+      id actual = va_arg(v, EXPBasicBlock);
+      obj = [[actual copy] autorelease];
   } else if((strstr(type, @encode(id)) != NULL) || (strstr(type, @encode(Class)) != 0)) {
     id actual = va_arg(v, id);
     obj = actual;
   } else if(strcmp(type, @encode(__typeof__(nil))) == 0) {
     obj = nil;
-  } else if(strstr(type, @encode(EXPBasicBlock)) != NULL) {
-    id actual = va_arg(v, EXPBasicBlock);
-    obj = [[actual copy] autorelease];
   } else if(strstr(type, "ff}{") != NULL) { //TODO: of course this only works for a 2x2 e.g. CGRect
     obj = [[[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[4]) size:4] autorelease];
   } else if(strstr(type, "=ff}") != NULL) {

--- a/test/MiscTest.m
+++ b/test/MiscTest.m
@@ -20,4 +20,12 @@
   expect(EXPDescribeObject(dict)).equal(@"{foo = bar;}");
 }
 
+- (void)test_EXPObjectifyCopiesObjectsWithBlockType
+{
+    id original = [[NSMutableArray alloc] init];
+    id copy = _EXPObjectify(@encode(EXPBasicBlock), original);
+    
+    expect(original == copy).to.beFalsy();
+}
+
 @end


### PR DESCRIPTION
Was crashing in the `raise` and `raiseAny` matchers, and generally whenever I pass a block to `expect()`. Tracked it down to _EXPObjectify treating the block as an ordinary object and failing to copy it.

Annoyingly, `@encode(EXPBasicBlock)` doesn't return a proper type encoding, it returns `"@?"`, which is treated as an ordinary object because the condition `strstr(type, @encode(id)) != NULL) || (strstr(type, @encode(Class)) != 0)` returns true.

I'm working around by moving the check for EXPBasicBlock before the check for id/class. Can't think of a better way to decide whether the object needs to be copied...
