### PR TITLE
Trigger a memory barrier when using 'will'

### DIFF
--- a/src/EXPExpect.m
+++ b/src/EXPExpect.m
@@ -4,6 +4,7 @@
 #import "EXPUnsupportedObject.h"
 #import "EXPMatcher.h"
 #import "EXPBlockDefinedMatcher.h"
+#import <libkern/OSAtomic.h>
 
 @implementation EXPExpect
 
@@ -100,6 +101,7 @@
             break;
           }
           [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+          OSMemoryBarrier();
           *actual = self.actual;
         }
       } else {


### PR DESCRIPTION
This won't magically make tests thread-safe, but it should reduce some races when the `will` matcher is waiting on a condition that will be fulfilled by another thread – for example:

``` objc
__block BOOL done = NO;
dispatch_async(someQueue, ^{
    done = YES;
});

expect(done).will.beTruthy();
```

Similar in concept to petejkim/specta#18.
