### PR TITLE
Support writing custom matchers under ARC

### DIFF
--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -12,6 +12,15 @@ void EXP_match(EXPBoolBlock block);
 void EXP_failureMessageForTo(EXPStringBlock block);
 void EXP_failureMessageForNotTo(EXPStringBlock block);
 
+#if __has_feature(objc_arc)
+#define _EXP_release(x)
+#define _EXP_autorelease(x) (x)
+
+#else
+#define _EXP_release(x) [x release]
+#define _EXP_autorelease(x) [x autorelease]
+#endif
+
 // workaround for the categories bug: http://developer.apple.com/library/mac/#qa/qa1490/_index.html
 #define EXPFixCategoriesBug(name) \
 @interface EXPFixCategoriesBug##name; @end \
@@ -42,7 +51,7 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
     } \
     [self applyMatcher:matcher to:&actual]; \
   }; \
-  [matcher release]; \
-  return [[matcherBlock copy] autorelease]; \
+  _EXP_release(matcher); \
+  return _EXP_autorelease([matcherBlock copy]); \
 } \
 @end


### PR DESCRIPTION
At present, you can't compile a custom matcher under ARC, as `_EXPMatcherImplementationEnd` contains explicit `release`/`autorelease` calls, which are illegal. This patch adds support for ARC when writing custom matchers.
