### PR TITLE
expecta mishandles C99's bool/_Bool type

### DIFF
--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -20,6 +20,10 @@ id _EXPObjectify(char *type, ...) {
   if(strcmp(type, @encode(char)) == 0) {
     char actual = (char)va_arg(v, int);
     obj = [NSNumber numberWithChar:actual];
+  } else if(strcmp(type, @encode(_Bool)) == 0) {
+    _Static_assert(sizeof(_Bool) <= sizeof(int), "Expected _Bool to be subject to vararg type promotion");
+    _Bool actual = (_Bool)va_arg(v, int);
+    obj = [NSNumber numberWithBool:actual];
   } else if(strcmp(type, @encode(double)) == 0) {
     double actual = (double)va_arg(v, double);
     obj = [NSNumber numberWithDouble:actual];

--- a/test/ExpectationTest.m
+++ b/test/ExpectationTest.m
@@ -174,4 +174,28 @@
   assertFail(test_expect(s).beNil(), @"expecting a struct is not supported");
 }
 
+- (void)test_boolean_type_equivalence {
+  bool noBool = false;
+  BOOL noBOOL = NO;
+  int noInt = 0;
+  id noNSNum = [NSNumber numberWithBool:NO];
+  
+  bool yesBool = true;
+  BOOL yesBOOL = YES;
+  int yesInt = 1;
+  id yesNSNum = [NSNumber numberWithBool:YES];
+  
+  expect(false).to.equal(NO);
+  expect(NO).to.equal(noBool);
+  expect(noBool).to.equal(noBOOL);
+  expect(noBOOL).to.equal(noInt);
+  expect(noInt).to.equal(noNSNum);
+  
+  expect(true).to.equal(YES);
+  expect(YES).to.equal(yesBool);
+  expect(yesBool).to.equal(yesBOOL);
+  expect(yesBOOL).to.equal(yesInt);
+  expect(yesInt).to.equal(yesNSNum);
+}
+
 @end


### PR DESCRIPTION
Currently `EXPObjectify` doesn't properly handle C99's boolean type: `EXPObjectify((bool)0)` returns `nil`, and `EXPObjectify((bool)1)` returns a pointer wrapped as an `NSValue`. This patch corrects this.
