### PR TITLE
Suppress warning about class definition with no base class

### DIFF
--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -14,7 +14,7 @@ void EXP_failureMessageForNotTo(EXPStringBlock block);
 
 // workaround for the categories bug: http://developer.apple.com/library/mac/#qa/qa1490/_index.html
 #define EXPFixCategoriesBug(name) \
-@interface EXPFixCategoriesBug##name; @end \
+NS_ROOT_CLASS @interface EXPFixCategoriesBug##name; @end \
 @implementation EXPFixCategoriesBug##name; @end
 
 #define _EXPMatcherInterface(matcherName, matcherArguments) \


### PR DESCRIPTION
`EXPMatcherImplementationBegin` triggers a compiler error on Xcode 4.6: "EXPFixCategoriesBug... defined without specifying a base class". This patch suppresses this warning.
