### PR TITLE
Ensure matcher category loading with constructors.

### DIFF
--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -14,8 +14,7 @@ void EXP_failureMessageForNotTo(EXPStringBlock block);
 
 // workaround for the categories bug: http://developer.apple.com/library/mac/#qa/qa1490/_index.html
 #define EXPFixCategoriesBug(name) \
-@interface EXPFixCategoriesBug##name; @end \
-@implementation EXPFixCategoriesBug##name; @end
+__attribute__((constructor)) static void EXPFixCategoriesBug##name() {}
 
 #define _EXPMatcherInterface(matcherName, matcherArguments) \
 @interface EXPExpect (matcherName##Matcher) \


### PR DESCRIPTION
This replaces the unused EXPFixCategoriesBug… classes with static constructor functions.

There are no warnings about classes not subclassing NSObject, the symbols can’t clash at link time, and it doesn’t pollute the runtime’s namespaces.

__attribute__((constructor)) is well-supported by both GCC and clang.
