### PR TITLE
Fix EXC_BAD_ACCESS from copying block after the matcher is freed

### DIFF
--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -43,14 +43,14 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
   __block void (^failureMessageForTo)(EXPStringBlock block) = ^(EXPStringBlock block) { EXP_failureMessageForTo(block); }; \
   __block void (^failureMessageForNotTo)(EXPStringBlock block) = ^(EXPStringBlock block) { EXP_failureMessageForNotTo(block); }; \
   prerequisite(nil); match(nil); failureMessageForTo(nil); failureMessageForNotTo(nil); \
-  void (^matcherBlock) matcherArguments = ^ matcherArguments { \
+  void (^matcherBlock) matcherArguments = [^ matcherArguments { \
     {
 
 #define _EXPMatcherImplementationEnd \
     } \
     [self applyMatcher:matcher to:&actual]; \
-  }; \
+  } copy]; \
   _EXP_release(matcher); \
-  return _EXP_autorelease([matcherBlock copy]); \
+  return _EXP_autorelease(matcherBlock); \
 } \
 @end


### PR DESCRIPTION
After updating to 0.2.2, I ran into some `EXC_BAD_ACCESS` errors in [-applyMatcher:to:](https://github.com/specta/expecta/blob/c57bd8b9cafe3b3614ce1b9fc35693b46eae3588/src/EXPExpect.m#L95-L96). My theory was that the matcher got prematurely freed somewhere.

Within `_EXPMatcherImplementationEnd`, the matcher is freed before the block gets a chance to retain it (since blocks only retain captured objects when copied). Moving the block copy earlier than the release seems to fix the issue.
