### PR TITLE
Add 'const' attribute to type of pointers to string literals

### DIFF
--- a/src/EXPExpect.h
+++ b/src/EXPExpect.h
@@ -15,7 +15,7 @@
 @property(nonatomic, readonly) id actual;
 @property(nonatomic, assign) id testCase;
 @property(nonatomic) int lineNumber;
-@property(nonatomic) char *fileName;
+@property(nonatomic) const char *fileName;
 @property(nonatomic) BOOL negative;
 @property(nonatomic) BOOL asynchronous;
 
@@ -25,8 +25,8 @@
 @property(nonatomic, readonly) EXPExpect *will;
 @property(nonatomic, readonly) EXPExpect *willNot;
 
-- (id)initWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(char *)fileName;
-+ (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(char *)fileName;
+- (id)initWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName;
++ (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName;
 
 - (void)applyMatcher:(id<EXPMatcher>)matcher;
 - (void)applyMatcher:(id<EXPMatcher>)matcher to:(NSObject **)actual;

--- a/src/EXPExpect.m
+++ b/src/EXPExpect.m
@@ -24,7 +24,7 @@
   lineNumber=_lineNumber,
   fileName=_fileName;
 
-- (id)initWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(char *)fileName {
+- (id)initWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName {
   self = [super init];
   if(self) {
     self.actualBlock = actualBlock;
@@ -43,7 +43,7 @@
   [super dealloc];
 }
 
-+ (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(char *)fileName {
++ (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName {
   return [[[EXPExpect alloc] initWithActualBlock:actualBlock testCase:(id)testCase lineNumber:lineNumber fileName:fileName] autorelease];
 }
 

--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -1,10 +1,10 @@
 #import "EXPExpect.h"
 #import "EXPBlockDefinedMatcher.h"
 
-id _EXPObjectify(char *type, ...);
-EXPExpect *_EXP_expect(id testCase, int lineNumber, char *fileName, EXPIdBlock actualBlock);
+id _EXPObjectify(const char *type, ...);
+EXPExpect *_EXP_expect(id testCase, int lineNumber, const char *fileName, EXPIdBlock actualBlock);
 
-void EXPFail(id testCase, int lineNumber, char *fileName, NSString *message);
+void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *message);
 NSString *EXPDescribeObject(id obj);
 
 void EXP_prerequisite(EXPBoolBlock block);

--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -13,7 +13,7 @@
 
 @end
 
-id _EXPObjectify(char *type, ...) {
+id _EXPObjectify(const char *type, ...) {
   va_list v;
   va_start(v, type);
   id obj = nil;
@@ -97,11 +97,11 @@ id _EXPObjectify(char *type, ...) {
   return obj;
 }
 
-EXPExpect *_EXP_expect(id testCase, int lineNumber, char *fileName, EXPIdBlock actualBlock) {
+EXPExpect *_EXP_expect(id testCase, int lineNumber, const char *fileName, EXPIdBlock actualBlock) {
   return [EXPExpect expectWithActualBlock:actualBlock testCase:testCase lineNumber:lineNumber fileName:fileName];
 }
 
-void EXPFail(id testCase, int lineNumber, char *fileName, NSString *message) {
+void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *message) {
   NSLog(@"%s:%d %@", fileName, lineNumber, message);
   NSString *reason = [NSString stringWithFormat:@"%s:%d %@", fileName, lineNumber, message];
   NSException *exception = [NSException exceptionWithName:@"Expecta Error" reason:reason userInfo:nil];


### PR DESCRIPTION
I'm trying to use Expecta in objective-c++ code and get some errors and warnings about non-const char\* pointer to some string literals. C++ is more strict in typechecking so this is a problem. 

I add 'const' attribute in every place where it should be.
