### PR TITLE
Make prerequesites asynchronous

### DIFF
--- a/src/matchers/EXPMatchers+haveCountOf.m
+++ b/src/matchers/EXPMatchers+haveCountOf.m
@@ -1,10 +1,12 @@
 #import "EXPMatchers+haveCountOf.h"
 
 EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSString class]] || [actual respondsToSelector:@selector(count)];
+  BOOL(^actualIsCompatible)(void) = ^BOOL {
+    return [actual isKindOfClass:[NSString class]] || [actual respondsToSelector:@selector(count)];
+  };
 
   prerequisite(^BOOL{
-    return actualIsCompatible;
+    return actualIsCompatible();
   });
 
   NSUInteger (^count)(id) = ^(id actual) {
@@ -16,19 +18,19 @@ EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
   };
 
   match(^BOOL{
-    if(actualIsCompatible) {
+    if(actualIsCompatible()) {
       return count(actual) == expected;
     }
     return NO;
   });
 
   failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+    if(!actualIsCompatible()) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ to have a count of %zi but got %zi", EXPDescribeObject(actual), expected, count(actual)];
   });
 
   failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+    if(!actualIsCompatible()) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ not to have a count of %zi", EXPDescribeObject(actual), expected];
   });
 }

--- a/test/AsynchronousTestingTest.m
+++ b/test/AsynchronousTestingTest.m
@@ -27,6 +27,14 @@
   assertFail(test_expect(foo).willNot.equal(@"foo"), @"expected: not foo, got: foo");
 }
 
+- (void)test_asynchronous_prerequisite {
+  __block NSArray *foo = nil;
+  [self performSelector:@selector(performBlock:) withObject:[[^{
+    foo = @[];
+  } copy] autorelease] afterDelay:0.1];
+  assertPass(test_expect(foo).will.haveCountOf(0));
+}
+
 - (void)test_Expecta_setAsynchronousTestTimeout {
   assertEquals([Expecta asynchronousTestTimeout], 1.0);
   [Expecta setAsynchronousTestTimeout: 10.0];


### PR DESCRIPTION
Currently prerequisites will fail prematurely when used asynchronously. For example:
    
    array = nil
    expect(array).will.haveCountOf(0)

    // sometime before the matcher times out
    array = @[]

will immediately fail because prerequisites are verified outside of the asynchronies logic. I propose matcher prerequisite to also be checked several times until the prerequisite met or until the matcher times out.

Note that this is a backwards incompatible change because most matchers evaluate their prerequisite only once when the matcher is created.

Edit: My use case is for a property that is nil until it's value is loaded over the network. Currently the asynchronous spec will always fail because `haveCountOf`'s prerequisite is that the value must be a kind of a certain class. My workaround for now is to set the value to a empty array.