### PR TITLE
Add XCTest support

### DIFF
--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -111,6 +111,11 @@ void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *messag
       exception = [NSException failureInFile:[NSString stringWithUTF8String:fileName] atLine:lineNumber withDescription:message];
     }
     [testCase failWithException:exception];
+  } else if(testCase && [testCase respondsToSelector:@selector(recordFailureWithDescription:inFile:atLine:expected:)]){
+      [testCase recordFailureWithDescription:message
+                                      inFile:[NSString stringWithUTF8String:fileName]
+                                      atLine:lineNumber
+                                    expected:NO];
   } else {
     [exception raise];
   }

--- a/src/NSObject+Expecta.h
+++ b/src/NSObject+Expecta.h
@@ -2,4 +2,8 @@
 
 @interface NSObject (Expecta)
 - (void)failWithException:(NSException *)exception;
+- (void)recordFailureWithDescription:(NSString *)description
+                              inFile:(NSString *)filename
+                              atLine:(NSUInteger)lineNumber
+                            expected:(BOOL)expected;
 @end


### PR DESCRIPTION
XCTest uses `recordFailureWithDescription:inFile:atLine:expected:` instead of `failWithException:`.
This pull request makes sure expecta uses the new method correctly.
Otherwise expecta would just throw an exception instead of a proper test failure.
