### PR TITLE
Make usage of NSArray literals a little bit simpler in equal()

### DIFF
--- a/src/matchers/EXPMatchers+equal.h
+++ b/src/matchers/EXPMatchers+equal.h
@@ -2,4 +2,4 @@
 
 EXPMatcherInterface(_equal, (id expected));
 EXPMatcherInterface(equal, (id expected)); // to aid code completion
-#define equal(expected) _equal(EXPObjectify((expected)))
+#define equal(...) _equal(EXPObjectify((__VA_ARGS__)))


### PR DESCRIPTION
This allows to write something like `expect(array).to.equal(@[ @"a", @"b", @"c" ])` without additional parentheses around the array literal.
