### PR TITLE
[WIP] ARC and modern Objective-C

### DIFF
--- a/Expecta.xcodeproj/project.pbxproj
+++ b/Expecta.xcodeproj/project.pbxproj
@@ -1328,9 +1328,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_ENABLE_OBJC_GC = supported;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/Expecta-Prefix.pch";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -1343,9 +1343,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_ENABLE_OBJC_GC = supported;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/Expecta-Prefix.pch";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/src/EXPBlockDefinedMatcher.m
+++ b/src/EXPBlockDefinedMatcher.m
@@ -10,16 +10,6 @@
 
 @implementation EXPBlockDefinedMatcher
 
-- (void)dealloc
-{
-    self.prerequisiteBlock = nil;
-    self.matchBlock = nil;
-    self.failureMessageForToBlock = nil;
-    self.failureMessageForNotToBlock = nil;
-    
-    [super dealloc];
-}
-
 @synthesize prerequisiteBlock;
 @synthesize matchBlock;
 @synthesize failureMessageForToBlock;

--- a/src/EXPDoubleTuple.m
+++ b/src/EXPDoubleTuple.m
@@ -15,7 +15,6 @@
 
 - (void)dealloc {
     free(self.values);
-    [super dealloc];
 }
 
 - (BOOL)isEqual:(id)object {

--- a/src/EXPExpect.h
+++ b/src/EXPExpect.h
@@ -4,7 +4,7 @@
 
 @interface EXPExpect : NSObject {
   EXPIdBlock _actualBlock;
-  id _testCase;
+  id __strong _testCase;
   int _lineNumber;
   char *_fileName;
   BOOL _negative;
@@ -13,7 +13,7 @@
 
 @property(nonatomic, copy) EXPIdBlock actualBlock;
 @property(nonatomic, readonly) id actual;
-@property(nonatomic, assign) id testCase;
+@property(nonatomic, strong) id testCase;
 @property(nonatomic) int lineNumber;
 @property(nonatomic) const char *fileName;
 @property(nonatomic) BOOL negative;

--- a/src/EXPExpect.m
+++ b/src/EXPExpect.m
@@ -37,14 +37,8 @@
   return self;
 }
 
-- (void)dealloc
-{
-  self.actualBlock = nil;
-  [super dealloc];
-}
-
 + (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName {
-  return [[[EXPExpect alloc] initWithActualBlock:actualBlock testCase:(id)testCase lineNumber:lineNumber fileName:fileName] autorelease];
+  return [[EXPExpect alloc] initWithActualBlock:actualBlock testCase:(id)testCase lineNumber:lineNumber fileName:fileName];
 }
 
 #pragma mark -
@@ -153,7 +147,6 @@
     EXPDynamicPredicateMatcher *matcher = [[EXPDynamicPredicateMatcher alloc] initWithExpectation:self selector:anInvocation.selector];
     [anInvocation setSelector:@selector(dispatch)];
     [anInvocation invokeWithTarget:matcher];
-    [matcher release];
   }
   else {
     [super forwardInvocation:anInvocation];
@@ -190,11 +183,11 @@
 
 - (void (^)(void))dispatch
 {
-  __block id blockExpectation = _expectation;
+  __unsafe_unretained id blockExpectation = _expectation;
 
-  return [[^{
+  return [^{
     [blockExpectation applyMatcher:self];
-  } copy] autorelease];
+  } copy];
 }
 
 @end

--- a/src/EXPFloatTuple.m
+++ b/src/EXPFloatTuple.m
@@ -15,7 +15,6 @@
 
 - (void)dealloc {
     free(self.values);
-    [super dealloc];
 }
 
 - (BOOL)isEqual:(id)object {

--- a/src/EXPUnsupportedObject.h
+++ b/src/EXPUnsupportedObject.h
@@ -4,7 +4,7 @@
   NSString *_type;
 }
 
-@property (nonatomic, retain) NSString *type;
+@property (nonatomic, strong) NSString *type;
 
 - (id)initWithType:(NSString *)type;
 

--- a/src/EXPUnsupportedObject.m
+++ b/src/EXPUnsupportedObject.m
@@ -12,9 +12,4 @@
   return self;
 }
 
-- (void)dealloc {
-  self.type = nil;
-  [super dealloc];
-}
-
 @end

--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -33,7 +33,7 @@ __attribute__((constructor)) static void EXPFixCategoriesBug##name() {}
 #define _EXPMatcherImplementationBegin(matcherName, matcherArguments) \
 EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 @implementation EXPExpect (matcherName##Matcher) \
-@dynamic matcherName;\
+\
 - (void(^) matcherArguments) matcherName { \
   EXPBlockDefinedMatcher *matcher = [[EXPBlockDefinedMatcher alloc] init]; \
   [[[NSThread currentThread] threadDictionary] setObject:matcher forKey:@"EXP_currentMatcher"]; \

--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -69,29 +69,29 @@ id _EXPObjectify(const char *type, ...) {
       // This condition must occur before the test for id/class type,
       // otherwise blocks will be treated as vanilla objects.
       id actual = va_arg(v, EXPBasicBlock);
-      obj = [[actual copy] autorelease];
+      obj = [actual copy];
   } else if((strstr(type, @encode(id)) != NULL) || (strstr(type, @encode(Class)) != 0)) {
     id actual = va_arg(v, id);
     obj = actual;
   } else if(strcmp(type, @encode(__typeof__(nil))) == 0) {
     obj = nil;
   } else if(strstr(type, "ff}{") != NULL) { //TODO: of course this only works for a 2x2 e.g. CGRect
-    obj = [[[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[4]) size:4] autorelease];
+    obj = [[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[4]) size:4];
   } else if(strstr(type, "=ff}") != NULL) {
-    obj = [[[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[2]) size:2] autorelease];
+    obj = [[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[2]) size:2];
   } else if(strstr(type, "=ffff}") != NULL) {
-    obj = [[[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[4]) size:4] autorelease];
+    obj = [[EXPFloatTuple alloc] initWithFloatValues:(float *)va_arg(v, float[4]) size:4];
   } else if(strstr(type, "dd}{") != NULL) { //TODO: same here
-    obj = [[[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[4]) size:4] autorelease];
+    obj = [[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[4]) size:4];
   } else if(strstr(type, "=dd}") != NULL) {
-    obj = [[[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[2]) size:2] autorelease];
+    obj = [[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[2]) size:2];
   } else if(strstr(type, "=dddd}") != NULL) {
-    obj = [[[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[4]) size:4] autorelease];
+    obj = [[EXPDoubleTuple alloc] initWithDoubleValues:(double *)va_arg(v, double[4]) size:4];
   } else if(type[0] == '{') {
-    EXPUnsupportedObject *actual = [[[EXPUnsupportedObject alloc] initWithType:@"struct"] autorelease];
+    EXPUnsupportedObject *actual = [[EXPUnsupportedObject alloc] initWithType:@"struct"];
     obj = actual;
   } else if(type[0] == '(') {
-    EXPUnsupportedObject *actual = [[[EXPUnsupportedObject alloc] initWithType:@"union"] autorelease];
+    EXPUnsupportedObject *actual = [[EXPUnsupportedObject alloc] initWithType:@"union"];
     obj = actual;
   } else {
     void *actual = va_arg(v, void *);

--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -139,7 +139,7 @@ NSString *EXPDescribeObject(id obj) {
         if(strcmp(type, @encode(SEL)) == 0) {
           return [NSString stringWithFormat:@"@selector(%@)", NSStringFromSelector([obj pointerValue])];
         } else if(strcmp(type, @encode(Class)) == 0) {
-          return NSStringFromClass(pointerValue);
+          return NSStringFromClass((__bridge Class)pointerValue);
         }
       }
     }

--- a/src/matchers/EXPMatchers+beIdenticalTo.h
+++ b/src/matchers/EXPMatchers+beIdenticalTo.h
@@ -1,9 +1,5 @@
 #import "Expecta.h"
 
-EXPMatcherInterface(_beIdenticalTo, (void *expected));
+EXPMatcherInterface(_beIdenticalTo, (id expected));
 
-#if __has_feature(objc_arc)
-#define beIdenticalTo(expected) _beIdenticalTo((__bridge void*)expected)
-#else
 #define beIdenticalTo _beIdenticalTo
-#endif

--- a/src/matchers/EXPMatchers+beIdenticalTo.m
+++ b/src/matchers/EXPMatchers+beIdenticalTo.m
@@ -1,12 +1,12 @@
 #import "EXPMatchers+equal.h"
 #import "EXPMatcherHelpers.h"
 
-EXPMatcherImplementationBegin(beIdenticalTo, (void *expected)) {
+EXPMatcherImplementationBegin(beIdenticalTo, (id expected)) {
   match(^BOOL{
     if(actual == expected) {
       return YES;
     } else if([actual isKindOfClass:[NSValue class]] && EXPIsValuePointer((NSValue *)actual)) {
-      if([(NSValue *)actual pointerValue] == expected) {
+      if([(NSValue *)actual pointerValue] == (__bridge void *)expected) {
         return YES;
       }
     }

--- a/src/matchers/EXPMatchers+raise.m
+++ b/src/matchers/EXPMatchers+raise.m
@@ -2,7 +2,7 @@
 #import "EXPDefines.h"
 
 EXPMatcherImplementationBegin(raise, (NSString *expectedExceptionName)) {
-  __block NSException *exceptionCaught = nil;
+  __block __unsafe_unretained NSException *exceptionCaught = nil;
 
   match(^BOOL{
     BOOL expectedExceptionCaught = NO;

--- a/src/matchers/EXPMatchers+raiseWithReason.m
+++ b/src/matchers/EXPMatchers+raiseWithReason.m
@@ -2,7 +2,7 @@
 #import "EXPDefines.h"
 
 EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName, NSString *expectedReason)) {
-    __block NSException *exceptionCaught = nil;
+    __block __unsafe_unretained NSException *exceptionCaught = nil;
     
     match(^BOOL{
         BOOL expectedExceptionCaught = NO;

--- a/test/AsynchronousTestingTest.m
+++ b/test/AsynchronousTestingTest.m
@@ -11,18 +11,18 @@
 
 - (void)test_isGoing {
   __block NSString *foo = @"";
-  [self performSelector:@selector(performBlock:) withObject:[[^{
+  [self performSelector:@selector(performBlock:) withObject:^{
     foo = @"foo";
-  } copy] autorelease] afterDelay:0.1];
+  } afterDelay:0.1];
   assertPass(test_expect(foo).will.equal(@"foo"));
   assertFail(test_expect(foo).will.equal(@"bar"), @"expected: bar, got: foo");
 }
 
 - (void)test_isNotGoing {
   __block NSString *foo = @"bar";
-  [self performSelector:@selector(performBlock:) withObject:[[^{
+  [self performSelector:@selector(performBlock:) withObject:[^{
     foo = @"foo";
-  } copy] autorelease] afterDelay:0.1];
+  } copy] afterDelay:0.1];
   assertPass(test_expect(foo).willNot.equal(@"bar"));
   assertFail(test_expect(foo).willNot.equal(@"foo"), @"expected: not foo, got: foo");
 }

--- a/test/AsynchronousTestingTest.m
+++ b/test/AsynchronousTestingTest.m
@@ -11,9 +11,9 @@
 
 - (void)test_isGoing {
   __block NSString *foo = @"";
-  [self performSelector:@selector(performBlock:) withObject:^{
+  [self performSelector:@selector(performBlock:) withObject:[^{
     foo = @"foo";
-  } afterDelay:0.1];
+  } copy] afterDelay:0.1];
   assertPass(test_expect(foo).will.equal(@"foo"));
   assertFail(test_expect(foo).will.equal(@"bar"), @"expected: bar, got: foo");
 }

--- a/test/CustomMatcherImplementationsTest.m
+++ b/test/CustomMatcherImplementationsTest.m
@@ -44,7 +44,6 @@ EXPMatcherInterface(_equalWithCustomMatcher, (id expected));
   return [^(id expected) {
     MyCustomMatcherImpl *customMatcher = [[MyCustomMatcherImpl alloc] initWithExpected:expected];
     [self applyMatcher:customMatcher];
-    [customMatcher release];
   } copy];
 }
 

--- a/test/EXPFailTest.h
+++ b/test/EXPFailTest.h
@@ -10,7 +10,7 @@
   NSException *_exception;
 }
 
-@property (nonatomic, retain) NSException *exception;
+@property (nonatomic, strong) NSException *exception;
 - (void)failWithException:(NSException *)exception;
 
 @end
@@ -23,8 +23,8 @@
   BOOL _expected;
 }
 
-@property (nonatomic, retain) NSString *description;
-@property (nonatomic, retain) NSString *fileName;
+@property (nonatomic, strong) NSString *description;
+@property (nonatomic, strong) NSString *fileName;
 @property (assign) NSUInteger lineNumber;
 @property (assign) BOOL expected;
 

--- a/test/EXPFailTest.m
+++ b/test/EXPFailTest.m
@@ -12,11 +12,6 @@
 @implementation TestCaseClassWithFailMethod
 @synthesize exception=_exception;
 
-- (void)dealloc {
-  self.exception = nil;
-  [super dealloc];
-}
-
 - (void)failWithException:(NSException *)exception {
   self.exception = exception;
 }
@@ -30,12 +25,6 @@
   fileName=_fileName,
   lineNumber=_lineNumber,
   expected=_expected;
-
-- (void)dealloc {
-  self.description = nil;
-  self.fileName = nil;
-  [super dealloc];
-}
 
 - (void)recordFailureWithDescription:(NSString *)description inFile:(NSString *)filename atLine:(NSUInteger)lineNumber expected:(BOOL)expected {
   self.description = description;
@@ -60,7 +49,6 @@
     assertEqualObjects([exception name], @"Expecta Error");
     assertEqualObjects([exception reason], @"test.m:777 epic fail");
   }
-  [testCase release];
 }
 
 #ifdef USE_XCTEST
@@ -89,7 +77,6 @@
   assertEqualObjects([exceptionUserInfo objectForKey:SenTestDescriptionKey], @"epic fail");
   assertEqualObjects([exceptionUserInfo objectForKey:SenTestFilenameKey], @"test.m");
   assertEqualObjects([exceptionUserInfo objectForKey:SenTestLineNumberKey], [NSNumber numberWithInt:777]);
-  [testCase release];
 }
 #endif
 

--- a/test/MiscTest.m
+++ b/test/MiscTest.m
@@ -22,10 +22,10 @@
 
 - (void)test_EXPObjectifyCopiesObjectsWithBlockType
 {
-    id original = [[NSMutableArray alloc] init];
+    id original = ^{ return @"foo"; };
     id copy = _EXPObjectify(@encode(EXPBasicBlock), original);
     
-    expect(original == copy).to.beFalsy();
+    expect(original).to.equal(copy);
 }
 
 @end

--- a/test/helpers/EXPExpect+Test.m
+++ b/test/helpers/EXPExpect+Test.m
@@ -4,7 +4,7 @@
 @implementation EXPExpect (Test)
 
 - (EXPExpect *)test {
-  self.testCase = [[FakeTestCase new] autorelease];
+  self.testCase = [FakeTestCase new];
   return self;
 }
 

--- a/test/matchers/EXPMatchers+beInstanceOfTest.m
+++ b/test/matchers/EXPMatchers+beInstanceOfTest.m
@@ -10,8 +10,8 @@
 @implementation EXPMatchers_beInstanceOfTest
 
 - (void)setUp {
-  foo = [[Foo new] autorelease];
-  bar = [[Bar new] autorelease];
+  foo = [Foo new];
+  bar = [Bar new];
   baz = foo;
 }
 

--- a/test/matchers/EXPMatchers+beKindOfTest.m
+++ b/test/matchers/EXPMatchers+beKindOfTest.m
@@ -11,9 +11,9 @@
 @implementation EXPMatchers_beKindOfTest
 
 - (void)setUp {
-  foo = [[Foo new] autorelease];
-  bar = [[Bar new] autorelease];
-  baz = [[Baz new] autorelease];
+  foo = [Foo new];
+  bar = [Bar new];
+  baz = [Baz new];
   qux = foo;
 }
 

--- a/test/matchers/EXPMatchers+equalTest.m
+++ b/test/matchers/EXPMatchers+equalTest.m
@@ -21,16 +21,12 @@
   NSObject *foo = [NSObject new], *bar = [NSObject new];
   assertPass(test_expect(foo).equal(foo));
   assertFail(test_expect(foo).equal(bar), ([NSString stringWithFormat:@"expected: %@, got: %@", bar, foo]));
-  [foo release];
-  [bar release];
 }
 
 - (void)test_toNot_equal_object {
   NSObject *foo = [NSObject new], *bar = [NSObject new];
   assertPass(test_expect(foo).toNot.equal(bar));
   assertFail(test_expect(foo).toNot.equal(foo), ([NSString stringWithFormat:@"expected: not %@, got: %@", foo, foo]));
-  [foo release];
-  [bar release];
 }
 
 - (void)test_equal_NSString {


### PR DESCRIPTION
:rotating_light: not ready to merge :rotating_light:

I've tried to start on #54 but I'm stumped on an issue that occurred.

[`- test_isGoing` in AsynchronousTestingTest.m fails](https://github.com/specta/expecta/blob/b0b85b935f83e55060af526b6a7dd7e6593a24aa/test/AsynchronousTestingTest.m#L12-L19) because, from what I can gather, the matcher's reference to `foo` is not updated after it's modified in the block and copied to the heap.

I'm thinking it could be the varargs in `_EXPObjectify` that trips up ARC so I'll investigate that next but if anyone has some ideas, I'd be happy to hear them.