### PR TITLE
Don't invoke -pointerValue on non-pointer NSValues

### DIFF
--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -131,16 +131,13 @@ void EXPFail(id testCase, int lineNumber, const char *fileName, NSString *messag
 NSString *EXPDescribeObject(id obj) {
   if(obj == nil) {
     return @"nil/null";
-  } else if([obj isKindOfClass:[NSValue class]]) {
-    if([obj isKindOfClass:[NSValue class]] && ![obj isKindOfClass:[NSNumber class]]) {
-      void *pointerValue = [obj pointerValue];
-      const char *type = [(NSValue *)obj _EXP_objCType];
-      if(type) {
-        if(strcmp(type, @encode(SEL)) == 0) {
-          return [NSString stringWithFormat:@"@selector(%@)", NSStringFromSelector([obj pointerValue])];
-        } else if(strcmp(type, @encode(Class)) == 0) {
-          return NSStringFromClass(pointerValue);
-        }
+  } else if([obj isKindOfClass:[NSValue class]] && ![obj isKindOfClass:[NSNumber class]]) {
+    const char *type = [(NSValue *)obj _EXP_objCType];
+    if(type) {
+      if(strcmp(type, @encode(SEL)) == 0) {
+        return [NSString stringWithFormat:@"@selector(%@)", NSStringFromSelector([obj pointerValue])];
+      } else if(strcmp(type, @encode(Class)) == 0) {
+        return NSStringFromClass([obj pointerValue]);
       }
     }
   }


### PR DESCRIPTION
This fixes a segfault when comparisons between geometric NSValues fail.
