### PR TITLE
Add NSAttributedString support to haveCountOf matcher

### DIFF
--- a/src/ExpectaSupport.m
+++ b/src/ExpectaSupport.m
@@ -161,6 +161,8 @@ NSString *EXPDescribeObject(id obj) {
       [arr addObject:[NSString stringWithFormat:@"%@ = %@;",EXPDescribeObject(k), EXPDescribeObject(v)]];
     }
     description = [NSString stringWithFormat:@"{%@}", [arr componentsJoinedByString:@" "]];
+  } else if([obj isKindOfClass:[NSAttributedString class]]) {
+    description = [obj string];
   } else {
     description = [description stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
   }

--- a/src/matchers/EXPMatchers+haveCountOf.m
+++ b/src/matchers/EXPMatchers+haveCountOf.m
@@ -1,14 +1,15 @@
 #import "EXPMatchers+haveCountOf.h"
 
 EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSString class]] || [actual respondsToSelector:@selector(count)];
+  BOOL actualIsStringy = [actual isKindOfClass:[NSString class]] || [actual isKindOfClass:[NSAttributedString class]];
+  BOOL actualIsCompatible = actualIsStringy || [actual respondsToSelector:@selector(count)];
 
   prerequisite(^BOOL{
     return actualIsCompatible;
   });
 
   NSUInteger (^count)(id) = ^(id actual) {
-    if([actual isKindOfClass:[NSString class]]) {
+    if(actualIsStringy) {
       return [actual length];
   } else {
       return [actual count];
@@ -23,12 +24,12 @@ EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
   });
 
   failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ to have a count of %zi but got %zi", EXPDescribeObject(actual), expected, count(actual)];
   });
 
   failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ not to have a count of %zi", EXPDescribeObject(actual), expected];
   });
 }

--- a/test/matchers/EXPMatchers+haveCountOfTest.m
+++ b/test/matchers/EXPMatchers+haveCountOfTest.m
@@ -6,6 +6,7 @@
   NSOrderedSet *orderedSet;
   NSDictionary* dictionary;
   NSString *string;
+  NSAttributedString *attributedString;
   NSObject* object;
 }
 @end
@@ -18,6 +19,7 @@
   orderedSet = [NSOrderedSet orderedSetWithObjects:@"foo", @"bar", @"baz", @"qux", nil];
   dictionary = [NSDictionary dictionaryWithObjectsAndKeys:@"value", @"key", nil];
   string = @"foobar";
+  attributedString = [[NSAttributedString alloc] initWithString:@"foobar"];
   object = [NSObject new];
 }
 
@@ -28,11 +30,13 @@
   assertPass(test_expect(orderedSet).haveCountOf(4));
   assertPass(test_expect(dictionary).haveCountOf(1));
   assertPass(test_expect(string).haveCountOf(6));
+  assertPass(test_expect(attributedString).haveCountOf(6));
   assertFail(test_expect(array).haveCountOf(2), @"expected (foo, bar, baz) to have a count of 2 but got 3");
   assertFail(test_expect(set).haveCountOf(3), @"expected {(foo, bar)} to have a count of 3 but got 2");
   assertFail(test_expect(orderedSet).haveCountOf(3), @"expected {(foo, bar, baz, qux)} to have a count of 3 but got 4");
   assertFail(test_expect(string).haveCountOf(3), @"expected foobar to have a count of 3 but got 6");
-  NSString* errorMessage = [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", object];
+  assertFail(test_expect(attributedString).haveCountOf(3), @"expected foobar to have a count of 3 but got 6");
+  NSString* errorMessage = [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", object];
   assertFail(test_expect(object).haveCountOf(2), errorMessage);
 }
 
@@ -41,11 +45,13 @@
   assertPass(test_expect(set).toNot.haveCountOf(3));
   assertPass(test_expect(dictionary).toNot.haveCountOf(6));
   assertPass(test_expect(string).toNot.haveCountOf(1));
+  assertPass(test_expect(attributedString).toNot.haveCountOf(1));
   assertFail(test_expect(array).toNot.haveCountOf(3), @"expected (foo, bar, baz) not to have a count of 3");
   assertFail(test_expect(set).notTo.haveCountOf(2), @"expected {(foo, bar)} not to have a count of 2");
   assertFail(test_expect(orderedSet).notTo.haveCountOf(4), @"expected {(foo, bar, baz, qux)} not to have a count of 4");
   assertFail(test_expect(string).toNot.haveCountOf(6), @"expected foobar not to have a count of 6");
-  NSString* errorMessage = [NSString stringWithFormat:@"%@ is not an instance of NSString, NSArray, NSSet, NSOrderedSet, or NSDictionary", object];
+  assertFail(test_expect(attributedString).toNot.haveCountOf(6), @"expected foobar not to have a count of 6");
+  NSString* errorMessage = [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", object];
   assertFail(test_expect(object).toNot.haveCountOf(2), errorMessage);
 }
 


### PR DESCRIPTION
This adds `NSAttributedString` as a compatible type for the `haveCountOf` matcher. I have found myself wanting this, and I think it makes sense given its close relationship to `NSString`.

I thought about checking if the `actual` object responds to `-length`, but I worried that it would too aggressively apply count-like semantics to all `-length` methods. In the end, checking for the `NSAttributedString` class was the quickest and easiest route,

Thanks for such a great project!
