### PR TITLE
Feature simplify apply matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ assertThat(@"foo", is(equalTo(@"foo")));
 assertThatUnsignedInteger(foo, isNot(equalToUnsignedInteger(1)));
 assertThatBool([bar isBar], is(equalToBool(YES)));
 assertThatDouble(baz, is(equalToDouble(3.14159)));
-``` vs. **Expecta **
+``` 
 
-```objective -
-    c expect(@"foo").to.equal(
-        @"foo"); // `to` is a syntatic sugar and can be safely omitted.
+vs. **Expecta**
+
+```objective-c
+expect(@"foo").to.equal(@"foo"); // `to` is a syntatic sugar and can be safely omitted.
 expect(foo).notTo.equal(1);
 expect([bar isBar]).to.equal(YES);
 expect(baz).to.equal(3.14159);

--- a/src/EXPBlockDefinedMatcher.m
+++ b/src/EXPBlockDefinedMatcher.m
@@ -28,7 +28,7 @@
 - (BOOL)meetsPrerequesiteFor:(id)actual
 {
   if (self.prerequisiteBlock) {
-    return self.prerequisiteBlock();
+    return self.prerequisiteBlock(actual);
   }
   return YES;
 }
@@ -36,7 +36,7 @@
 - (BOOL)matches:(id)actual
 {
   if (self.matchBlock) {
-    return self.matchBlock();
+    return self.matchBlock(actual);
   }
   return YES;
 }
@@ -44,7 +44,7 @@
 - (NSString *)failureMessageForTo:(id)actual
 {
   if (self.failureMessageForToBlock) {
-    return self.failureMessageForToBlock();
+    return self.failureMessageForToBlock(actual);
   }
   return nil;
 }
@@ -52,7 +52,7 @@
 - (NSString *)failureMessageForNotTo:(id)actual
 {
   if (self.failureMessageForNotToBlock) {
-    return self.failureMessageForNotToBlock();
+    return self.failureMessageForNotToBlock(actual);
   }
   return nil;
 }

--- a/src/EXPDefines.h
+++ b/src/EXPDefines.h
@@ -11,7 +11,7 @@
 
 typedef void (^EXPBasicBlock)();
 typedef id (^EXPIdBlock)();
-typedef BOOL (^EXPBoolBlock)();
-typedef NSString *(^EXPStringBlock)();
+typedef BOOL (^EXPBoolBlock)(id actual);
+typedef NSString *(^EXPStringBlock)(id actual);
 
 #endif

--- a/src/EXPExpect.h
+++ b/src/EXPExpect.h
@@ -29,7 +29,6 @@
 + (EXPExpect *)expectWithActualBlock:(id)actualBlock testCase:(id)testCase lineNumber:(int)lineNumber fileName:(const char *)fileName;
 
 - (void)applyMatcher:(id<EXPMatcher>)matcher;
-- (void)applyMatcher:(id<EXPMatcher>)matcher to:(NSObject **)actual;
 
 @end
 

--- a/src/EXPExpect.m
+++ b/src/EXPExpect.m
@@ -83,17 +83,14 @@
 - (void)applyMatcher:(id<EXPMatcher>)matcher
 {
   id actual = [self actual];
-  [self applyMatcher:matcher to:&actual];
-}
 
-- (void)applyMatcher:(id<EXPMatcher>)matcher to:(NSObject **)actual {
-  if([*actual isKindOfClass:[EXPUnsupportedObject class]]) {
+  if([actual isKindOfClass:[EXPUnsupportedObject class]]) {
     EXPFail(self.testCase, self.lineNumber, self.fileName,
-            [NSString stringWithFormat:@"expecting a %@ is not supported", ((EXPUnsupportedObject *)*actual).type]);
+            [NSString stringWithFormat:@"expecting a %@ is not supported", ((EXPUnsupportedObject *)actual).type]);
   } else {
     BOOL failed = NO;
     if([matcher respondsToSelector:@selector(meetsPrerequesiteFor:)] &&
-       ![matcher meetsPrerequesiteFor:*actual]) {
+       ![matcher meetsPrerequesiteFor:actual]) {
       failed = YES;
     } else {
       BOOL matchResult = NO;
@@ -101,17 +98,17 @@
         NSTimeInterval timeOut = [Expecta asynchronousTestTimeout];
         NSDate *expiryDate = [NSDate dateWithTimeIntervalSinceNow:timeOut];
         while(1) {
-          matchResult = [matcher matches:*actual];
+          matchResult = [matcher matches:actual];
           failed = self.negative ? matchResult : !matchResult;
           if(!failed || ([(NSDate *)[NSDate date] compare:expiryDate] == NSOrderedDescending)) {
             break;
           }
           [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
           OSMemoryBarrier();
-          *actual = self.actual;
+          actual = [self actual];
         }
       } else {
-        matchResult = [matcher matches:*actual];
+        matchResult = [matcher matches:actual];
       }
       failed = self.negative ? matchResult : !matchResult;
     }
@@ -120,11 +117,11 @@
 
       if(self.negative) {
         if ([matcher respondsToSelector:@selector(failureMessageForNotTo:)]) {
-          message = [matcher failureMessageForNotTo:*actual];
+          message = [matcher failureMessageForNotTo:actual];
         }
       } else {
         if ([matcher respondsToSelector:@selector(failureMessageForTo:)]) {
-          message = [matcher failureMessageForTo:*actual];
+          message = [matcher failureMessageForTo:actual];
         }
       }
       if (message == nil) {

--- a/src/ExpectaSupport.h
+++ b/src/ExpectaSupport.h
@@ -37,7 +37,6 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 - (void(^) matcherArguments) matcherName { \
   EXPBlockDefinedMatcher *matcher = [[EXPBlockDefinedMatcher alloc] init]; \
   [[[NSThread currentThread] threadDictionary] setObject:matcher forKey:@"EXP_currentMatcher"]; \
-  __block id actual = self.actual; \
   __block void (^prerequisite)(EXPBoolBlock block) = ^(EXPBoolBlock block) { EXP_prerequisite(block); }; \
   __block void (^match)(EXPBoolBlock block) = ^(EXPBoolBlock block) { EXP_match(block); }; \
   __block void (^failureMessageForTo)(EXPStringBlock block) = ^(EXPStringBlock block) { EXP_failureMessageForTo(block); }; \
@@ -48,7 +47,7 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 
 #define _EXPMatcherImplementationEnd \
     } \
-    [self applyMatcher:matcher to:&actual]; \
+    [self applyMatcher:matcher]; \
   } copy]; \
   _EXP_release(matcher); \
   return _EXP_autorelease(matcherBlock); \

--- a/src/matchers/EXPMatchers+beCloseTo.m
+++ b/src/matchers/EXPMatchers+beCloseTo.m
@@ -2,13 +2,13 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
-  prerequisite(^BOOL{
+  prerequisite(^BOOL(id actual){
     return [actual isKindOfClass:[NSNumber class]] &&
 		[expected isKindOfClass:[NSNumber class]] &&
 		([within isKindOfClass:[NSNumber class]] || (within == nil));
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual){
 		double actualValue = [actual doubleValue];
 		double expectedValue = [expected doubleValue];
 
@@ -26,7 +26,7 @@ EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
 		}
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     if (within) {
       return [NSString stringWithFormat:@"expected %@ to be close to %@ within %@",
               EXPDescribeObject(actual), EXPDescribeObject(expected), EXPDescribeObject(within)];
@@ -36,7 +36,7 @@ EXPMatcherImplementationBegin(_beCloseToWithin, (id expected, id within)) {
     }
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     if (within) {
       return [NSString stringWithFormat:@"expected %@ not to be close to %@ within %@",
               EXPDescribeObject(actual), EXPDescribeObject(expected), EXPDescribeObject(within)];

--- a/src/matchers/EXPMatchers+beFalsy.m
+++ b/src/matchers/EXPMatchers+beFalsy.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(beFalsy, (void)) {
-  match(^BOOL{
+  match(^BOOL(id actual){
     if([actual isKindOfClass:[NSNumber class]]) {
       return ![(NSNumber *)actual boolValue];
     } else if([actual isKindOfClass:[NSValue class]]) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(beFalsy, (void)) {
     return !actual;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: a falsy value, got: %@, which is truthy", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: a non-falsy value, got: %@, which is falsy", EXPDescribeObject(actual)];
   });
 }

--- a/src/matchers/EXPMatchers+beGreaterThan.m
+++ b/src/matchers/EXPMatchers+beGreaterThan.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beGreaterThan, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual){
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] == NSOrderedDescending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ to be greater than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ not to be greater than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/src/matchers/EXPMatchers+beGreaterThanOrEqualTo.m
+++ b/src/matchers/EXPMatchers+beGreaterThanOrEqualTo.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beGreaterThanOrEqualTo, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual){
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] != NSOrderedAscending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ to be greater than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ not to be greater than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/src/matchers/EXPMatchers+beIdenticalTo.m
+++ b/src/matchers/EXPMatchers+beIdenticalTo.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(beIdenticalTo, (void *expected)) {
-  match(^BOOL{
+  match(^BOOL(id actual){
     if(actual == expected) {
       return YES;
     } else if([actual isKindOfClass:[NSValue class]] && EXPIsValuePointer((NSValue *)actual)) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(beIdenticalTo, (void *expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: <%p>, got: <%p>", expected, actual];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: not <%p>, got: <%p>", expected, actual];
   });
 }

--- a/src/matchers/EXPMatchers+beInTheRangeOf.m
+++ b/src/matchers/EXPMatchers+beInTheRangeOf.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beInTheRangeOf, (id expectedLowerBound, id expectedUpperBound)) {
-    match(^BOOL{
+    match(^BOOL(id actual){
         if ([actual respondsToSelector:@selector(compare:)]) {
             NSComparisonResult compareLowerBound = [expectedLowerBound compare: actual];
             NSComparisonResult compareUpperBound = [expectedUpperBound compare: actual];
@@ -19,11 +19,11 @@ EXPMatcherImplementationBegin(_beInTheRangeOf, (id expectedLowerBound, id expect
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ to be in the range [%@, %@] (inclusive)", EXPDescribeObject(actual), EXPDescribeObject(expectedLowerBound), EXPDescribeObject(expectedUpperBound)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ not to be in the range [%@, %@] (inclusive)", EXPDescribeObject(actual), EXPDescribeObject(expectedLowerBound), EXPDescribeObject(expectedUpperBound)];
     });
 }

--- a/src/matchers/EXPMatchers+beInstanceOf.m
+++ b/src/matchers/EXPMatchers+beInstanceOf.m
@@ -1,25 +1,25 @@
 #import "EXPMatchers+beInstanceOf.h"
 
 EXPMatcherImplementationBegin(beInstanceOf, (Class expected)) {
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
   BOOL expectedIsNil = (expected == nil);
 
-  prerequisite(^BOOL{
-    return !(actualIsNil || expectedIsNil);
+  prerequisite(^BOOL(id actual){
+    return !(actualIsNil(actual) || expectedIsNil);
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual){
     return [actual isMemberOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
+  failureMessageForTo(^NSString *(id actual){
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: an instance of %@, got: an instance of %@", [expected class], [actual class]];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
+  failureMessageForNotTo(^NSString *(id actual){
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: not an instance of %@, got: an instance of %@", [expected class], [actual class]];
   });

--- a/src/matchers/EXPMatchers+beKindOf.m
+++ b/src/matchers/EXPMatchers+beKindOf.m
@@ -1,25 +1,25 @@
 #import "EXPMatchers+beKindOf.h"
 
 EXPMatcherImplementationBegin(beKindOf, (Class expected)) {
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual) { return (actual == nil); };
   BOOL expectedIsNil = (expected == nil);
 
-  prerequisite(^BOOL{
-    return !(actualIsNil || expectedIsNil);
+  prerequisite(^BOOL(id actual){
+    return !(actualIsNil(actual) || expectedIsNil);
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual){
     return [actual isKindOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
+  failureMessageForTo(^NSString *(id actual){
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: a kind of %@, got: an instance of %@, which is not a kind of %@", [expected class], [actual class], [expected class]];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(actualIsNil) return @"the actual value is nil/null";
+  failureMessageForNotTo(^NSString *(id actual){
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected: not a kind of %@, got: an instance of %@, which is a kind of %@", [expected class], [actual class], [expected class]];
   });

--- a/src/matchers/EXPMatchers+beLessThan.m
+++ b/src/matchers/EXPMatchers+beLessThan.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beLessThan, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual){
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] == NSOrderedAscending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ to be less than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ not to be less than %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/src/matchers/EXPMatchers+beLessThanOrEqualTo.m
+++ b/src/matchers/EXPMatchers+beLessThanOrEqualTo.m
@@ -2,18 +2,18 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_beLessThanOrEqualTo, (id expected)) {
-    match(^BOOL{
+    match(^BOOL(id actual){
         if ([actual respondsToSelector:@selector(compare:)]) {
             return [actual compare:expected] != NSOrderedDescending;
         }
         return NO;
     });
 
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ to be less than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ not to be less than or equal to %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
     });
 }

--- a/src/matchers/EXPMatchers+beNil.m
+++ b/src/matchers/EXPMatchers+beNil.m
@@ -1,15 +1,15 @@
 #import "EXPMatchers+beNil.h"
 
 EXPMatcherImplementationBegin(beNil, (void)) {
-  match(^BOOL{
+  match(^BOOL(id actual){
     return actual == nil;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: nil/null, got: %@", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: not nil/null, got: %@", EXPDescribeObject(actual)];
   });
 }

--- a/src/matchers/EXPMatchers+beSubclassOf.m
+++ b/src/matchers/EXPMatchers+beSubclassOf.m
@@ -5,21 +5,21 @@
 EXPMatcherImplementationBegin(beSubclassOf, (Class expected)) {
   __block BOOL actualIsClass = YES;
 
-  prerequisite(^BOOL {
+  prerequisite(^BOOL(id actual){
     actualIsClass = class_isMetaClass(object_getClass(actual));
     return actualIsClass;
   });
 
-  match(^BOOL{
+  match(^BOOL(id actual){
     return [actual isSubclassOfClass:expected];
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     if(!actualIsClass) return @"the actual value is not a Class";
     return [NSString stringWithFormat:@"expected: a subclass of %@, got: a class %@, which is not a subclass of %@", [expected class], actual, [expected class]];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     if(!actualIsClass) return @"the actual value is not a Class";
     return [NSString stringWithFormat:@"expected: not a subclass of %@, got: a class %@, which is a subclass of %@", [expected class], actual, [expected class]];
   });

--- a/src/matchers/EXPMatchers+beSupersetOf.m
+++ b/src/matchers/EXPMatchers+beSupersetOf.m
@@ -1,16 +1,16 @@
 #import "EXPMatchers+contain.h"
 
 EXPMatcherImplementationBegin(beSupersetOf, (id subset)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSDictionary class]] || [actual respondsToSelector:@selector(containsObject:)];
+  BOOL (^actualIsCompatible)(id actual) = ^BOOL(id actual){ return [actual isKindOfClass:[NSDictionary class]] || [actual respondsToSelector:@selector(containsObject:)]; };
   BOOL subsetIsNil = (subset == nil);
-  BOOL classMatches = [subset isKindOfClass:[actual class]];
+  BOOL (^classMatches)(id actual) = ^BOOL(id actual){ return [subset isKindOfClass:[actual class]]; };
 
-  prerequisite(^BOOL{
-    return actualIsCompatible && !subsetIsNil && classMatches;
+  prerequisite(^BOOL(id actual){
+    return actualIsCompatible(actual) && !subsetIsNil && classMatches(actual);
   });
 
-  match(^BOOL{
-    if(!actualIsCompatible) return NO;
+  match(^BOOL(id actual){
+    if(!actualIsCompatible(actual)) return NO;
 
     if([actual isKindOfClass:[NSDictionary class]]) {
       for (id key in subset) {
@@ -28,22 +28,22 @@ EXPMatcherImplementationBegin(beSupersetOf, (id subset)) {
     return YES;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
 
     if(subsetIsNil) return @"the expected value is nil/null";
 
-    if(!classMatches) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
+    if(!classMatches(actual)) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
 
     return [NSString stringWithFormat:@"expected %@ to be a superset of %@", EXPDescribeObject(actual), EXPDescribeObject(subset)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSDictionary and does not implement -containsObject:", EXPDescribeObject(actual)];
 
     if(subsetIsNil) return @"the expected value is nil/null";
 
-    if(!classMatches) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
+    if(!classMatches(actual)) return [NSString stringWithFormat:@"%@ does not match the class of %@", EXPDescribeObject(subset), EXPDescribeObject(actual)];
 
     return [NSString stringWithFormat:@"expected %@ not to be a superset of %@", EXPDescribeObject(actual), EXPDescribeObject(subset)];
   });

--- a/src/matchers/EXPMatchers+beTruthy.m
+++ b/src/matchers/EXPMatchers+beTruthy.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(beTruthy, (void)) {
-  match(^BOOL{
+  match(^BOOL(id actual){
     if([actual isKindOfClass:[NSNumber class]]) {
       return !![(NSNumber *)actual boolValue];
     } else if([actual isKindOfClass:[NSValue class]]) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(beTruthy, (void)) {
     return !!actual;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: a truthy value, got: %@, which is falsy", EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: a non-truthy value, got: %@, which is truthy", EXPDescribeObject(actual)];
   });
 }

--- a/src/matchers/EXPMatchers+beginWith.m
+++ b/src/matchers/EXPMatchers+beginWith.m
@@ -1,18 +1,20 @@
 #import "EXPMatchers+beginWith.h"
 
 EXPMatcherImplementationBegin(beginWith, (id expected)) {
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
   BOOL expectedIsNil = (expected == nil);
   //This condition allows the comparison of an immutable string or ordered collection to the mutable type of the same
-  BOOL actualAndExpectedAreCompatible = (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
-                                         || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
-                                         || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
+  BOOL (^actualAndExpectedAreCompatible)(id actual) = ^BOOL(id actual){
+    return (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
+            || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
+            || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
+  };
   
-  prerequisite(^BOOL {
-    return actualAndExpectedAreCompatible;
+  prerequisite(^BOOL(id actual){
+    return actualAndExpectedAreCompatible(actual);
   });
   
-  match(^BOOL {
+  match(^BOOL(id actual){
     if ([actual isKindOfClass:[NSString class]]) {
       return [actual hasPrefix:expected];
     } else if ([actual isKindOfClass:[NSArray class]]) {
@@ -31,17 +33,17 @@ EXPMatcherImplementationBegin(beginWith, (id expected)) {
     }
   });
   
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     return [NSString stringWithFormat:@"expected: %@ to begin with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
   
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForNotTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     
     return [NSString stringWithFormat:@"expected: %@ not to begin with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/src/matchers/EXPMatchers+conformTo.m
+++ b/src/matchers/EXPMatchers+conformTo.m
@@ -3,27 +3,27 @@
 #import <objc/runtime.h>
 
 EXPMatcherImplementationBegin(conformTo, (Protocol *expected)) {
-    BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
     BOOL expectedIsNil = (expected == nil);
 
-    prerequisite(^BOOL{
-        return !(actualIsNil || expectedIsNil);
+    prerequisite(^BOOL(id actual){
+        return !(actualIsNil(actual) || expectedIsNil);
     });
 
-    match(^BOOL{
+    match(^BOOL(id actual){
         return [actual conformsToProtocol:expected];
     });
 
-    failureMessageForTo(^NSString *{
-        if(actualIsNil) return @"the object is nil/null";
+    failureMessageForTo(^NSString *(id actual){
+        if(actualIsNil(actual)) return @"the object is nil/null";
         if(expectedIsNil) return @"the protocol is nil/null";
 
         NSString *name = NSStringFromProtocol(expected);
         return [NSString stringWithFormat:@"expected: %@ to conform to %@", actual, name];
     });
 
-    failureMessageForNotTo(^NSString *{
-        if(actualIsNil) return @"the object is nil/null";
+    failureMessageForNotTo(^NSString *(id actual){
+        if(actualIsNil(actual)) return @"the object is nil/null";
         if(expectedIsNil) return @"the protocol is nil/null";
 
         NSString *name = NSStringFromProtocol(expected);

--- a/src/matchers/EXPMatchers+contain.m
+++ b/src/matchers/EXPMatchers+contain.m
@@ -1,15 +1,15 @@
 #import "EXPMatchers+contain.h"
 
 EXPMatcherImplementationBegin(_contain, (id expected)) {
-  BOOL actualIsCompatible = [actual isKindOfClass:[NSString class]] || [actual conformsToProtocol:@protocol(NSFastEnumeration)];
+  BOOL (^actualIsCompatible)(id actual) = ^BOOL(id actual){ return [actual isKindOfClass:[NSString class]] || [actual conformsToProtocol:@protocol(NSFastEnumeration)]; };
   BOOL expectedIsNil = (expected == nil);
 
-  prerequisite(^BOOL{
-    return actualIsCompatible && !expectedIsNil;
+  prerequisite(^BOOL(id actual){
+    return actualIsCompatible(actual) && !expectedIsNil;
   });
 
-  match(^BOOL{
-    if(actualIsCompatible) {
+  match(^BOOL(id actual){
+    if(actualIsCompatible(actual)) {
       if([actual isKindOfClass:[NSString class]]) {
         return [(NSString *)actual rangeOfString:[expected description]].location != NSNotFound;
       } else {
@@ -23,14 +23,14 @@ EXPMatcherImplementationBegin(_contain, (id expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected %@ to contain %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString or NSFastEnumeration", EXPDescribeObject(actual)];
     if(expectedIsNil) return @"the expected value is nil/null";
     return [NSString stringWithFormat:@"expected %@ not to contain %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/src/matchers/EXPMatchers+endWith.m
+++ b/src/matchers/EXPMatchers+endWith.m
@@ -1,18 +1,20 @@
 #import "EXPMatchers+endWith.h"
 
 EXPMatcherImplementationBegin(endWith, (id expected)) {
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
   BOOL expectedIsNil = (expected == nil);
   //This condition allows the comparison of an immutable string or ordered collection to the mutable type of the same
-  BOOL actualAndExpectedAreCompatible = (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
-                                         || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
-                                         || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
+  BOOL (^actualAndExpectedAreCompatible)(id actual) = ^BOOL(id actual){
+    return (([actual isKindOfClass:[NSString class]] && [expected isKindOfClass:[NSString class]])
+            || ([actual isKindOfClass:[NSArray class]] && [expected isKindOfClass:[NSArray class]])
+            || ([actual isKindOfClass:[NSOrderedSet class]] && [expected isKindOfClass:[NSOrderedSet class]]));
+  };
   
-  prerequisite(^BOOL {
-    return actualAndExpectedAreCompatible;
+  prerequisite(^BOOL(id actual){
+    return actualAndExpectedAreCompatible(actual);
   });
   
-  match(^BOOL {
+  match(^BOOL(id actual){
     if ([actual isKindOfClass:[NSString class]]) {
       return [actual hasSuffix:expected];
     } else if ([actual isKindOfClass:[NSArray class]]) {
@@ -31,17 +33,17 @@ EXPMatcherImplementationBegin(endWith, (id expected)) {
     }
   });
   
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     return [NSString stringWithFormat:@"expected: %@ to end with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });
   
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForNotTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNil) return @"the expected value is nil/null";
-    if (!actualAndExpectedAreCompatible) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
+    if (!actualAndExpectedAreCompatible(actual)) return [NSString stringWithFormat:@"%@ and %@ are not instances of one of %@, %@, or %@", EXPDescribeObject(actual), EXPDescribeObject(expected), [NSString class], [NSArray class], [NSOrderedSet class]];
     
     return [NSString stringWithFormat:@"expected: %@ not to end with %@", EXPDescribeObject(actual), EXPDescribeObject(expected)];
   });

--- a/src/matchers/EXPMatchers+equal.m
+++ b/src/matchers/EXPMatchers+equal.m
@@ -2,7 +2,7 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(_equal, (id expected)) {
-  match(^BOOL{
+  match(^BOOL(id actual){
     if((actual == expected) || [actual isEqual:expected]) {
       return YES;
     } else if([actual isKindOfClass:[NSNumber class]] && [expected isKindOfClass:[NSNumber class]]) {
@@ -13,11 +13,11 @@ EXPMatcherImplementationBegin(_equal, (id expected)) {
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: %@, got: %@", EXPDescribeObject(expected), EXPDescribeObject(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: not %@, got: %@", EXPDescribeObject(expected), EXPDescribeObject(actual)];
   });
 }

--- a/src/matchers/EXPMatchers+haveCountOf.m
+++ b/src/matchers/EXPMatchers+haveCountOf.m
@@ -1,35 +1,35 @@
 #import "EXPMatchers+haveCountOf.h"
 
 EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
-  BOOL actualIsStringy = [actual isKindOfClass:[NSString class]] || [actual isKindOfClass:[NSAttributedString class]];
-  BOOL actualIsCompatible = actualIsStringy || [actual respondsToSelector:@selector(count)];
+  BOOL (^actualIsStringy)(id actual) = ^BOOL(id actual){ return [actual isKindOfClass:[NSString class]] || [actual isKindOfClass:[NSAttributedString class]]; };
+  BOOL (^actualIsCompatible)(id actual) = ^BOOL(id actual){  return actualIsStringy(actual) || [actual respondsToSelector:@selector(count)]; };
 
-  prerequisite(^BOOL{
-    return actualIsCompatible;
+  prerequisite(^BOOL(id actual){
+    return actualIsCompatible(actual);
   });
 
   NSUInteger (^count)(id) = ^(id actual) {
-    if(actualIsStringy) {
+    if(actualIsStringy(actual)) {
       return [actual length];
   } else {
       return [actual count];
     }
   };
 
-  match(^BOOL{
-    if(actualIsCompatible) {
+  match(^BOOL(id actual){
+    if(actualIsCompatible(actual)) {
       return count(actual) == expected;
     }
     return NO;
   });
 
-  failureMessageForTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+  failureMessageForTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ to have a count of %zi but got %zi", EXPDescribeObject(actual), expected, count(actual)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if(!actualIsCompatible) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
+  failureMessageForNotTo(^NSString *(id actual){
+    if(!actualIsCompatible(actual)) return [NSString stringWithFormat:@"%@ is not an instance of NSString, NSAttributedString, NSArray, NSSet, NSOrderedSet, or NSDictionary", EXPDescribeObject(actual)];
     return [NSString stringWithFormat:@"expected %@ not to have a count of %zi", EXPDescribeObject(actual), expected];
   });
 }

--- a/src/matchers/EXPMatchers+notify.m
+++ b/src/matchers/EXPMatchers+notify.m
@@ -1,7 +1,7 @@
 #import "EXPMatchers+notify.h"
 
 EXPMatcherImplementationBegin(notify, (id expected)){
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
   BOOL expectedIsNil = (expected == nil);
   BOOL isNotification = [expected isKindOfClass:[NSNotification class]];
   BOOL isName = [expected isKindOfClass:[NSString class]];
@@ -10,9 +10,9 @@ EXPMatcherImplementationBegin(notify, (id expected)){
   __block BOOL expectedNotificationOccurred = NO;
   __block id observer;
   
-  prerequisite(^BOOL{
+  prerequisite(^BOOL(id actual){
     expectedNotificationOccurred = NO;
-    if (actualIsNil || expectedIsNil) return NO;
+    if (actualIsNil(actual) || expectedIsNil) return NO;
     if (isNotification) {
       expectedName = [expected name];
     }else if(isName) {
@@ -32,28 +32,28 @@ EXPMatcherImplementationBegin(notify, (id expected)){
     return YES;
   });
   
-  match(^BOOL{
+  match(^BOOL(id actual){
     if(expectedNotificationOccurred) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
     return expectedNotificationOccurred;
   });
   
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
-    if(actualIsNil) return @"the actual value is nil/null";
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     if(!(isNotification || isName)) return @"the actual value is not a notification or string";
     return [NSString stringWithFormat:@"expected: %@, got: none",expectedName];
   });
   
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
-    if(actualIsNil) return @"the actual value is nil/null";
+    if(actualIsNil(actual)) return @"the actual value is nil/null";
     if(expectedIsNil) return @"the expected value is nil/null";
     if(!(isNotification || isName)) return @"the actual value is not a notification or string";
     return [NSString stringWithFormat:@"expected: none, got: %@", expectedName];

--- a/src/matchers/EXPMatchers+raise.m
+++ b/src/matchers/EXPMatchers+raise.m
@@ -4,7 +4,7 @@
 EXPMatcherImplementationBegin(raise, (NSString *expectedExceptionName)) {
   __block NSException *exceptionCaught = nil;
 
-  match(^BOOL{
+  match(^BOOL(id actual){
     BOOL expectedExceptionCaught = NO;
     @try {
       ((EXPBasicBlock)actual)();
@@ -15,13 +15,13 @@ EXPMatcherImplementationBegin(raise, (NSString *expectedExceptionName)) {
     return expectedExceptionCaught;
   });
 
-  failureMessageForTo(^NSString *{
+  failureMessageForTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: %@, got: %@",
             expectedExceptionName ? expectedExceptionName : @"any exception",
             exceptionCaught ? [exceptionCaught name] : @"no exception"];
   });
 
-  failureMessageForNotTo(^NSString *{
+  failureMessageForNotTo(^NSString *(id actual){
     return [NSString stringWithFormat:@"expected: %@, got: %@",
             expectedExceptionName ? [NSString stringWithFormat:@"not %@", expectedExceptionName] : @"no exception",
             exceptionCaught ? [exceptionCaught name] : @"no exception"];

--- a/src/matchers/EXPMatchers+raiseWithReason.m
+++ b/src/matchers/EXPMatchers+raiseWithReason.m
@@ -4,7 +4,7 @@
 EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName, NSString *expectedReason)) {
     __block NSException *exceptionCaught = nil;
     
-    match(^BOOL{
+    match(^BOOL(id actual){
         BOOL expectedExceptionCaught = NO;
         @try {
             ((EXPBasicBlock)actual)();
@@ -16,7 +16,7 @@ EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName,
         return expectedExceptionCaught;
     });
     
-    failureMessageForTo(^NSString *{
+    failureMessageForTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ (%@), got: %@ (%@)",
                 expectedExceptionName ?: @"any exception",
                 expectedReason ?: @"any reason",
@@ -24,7 +24,7 @@ EXPMatcherImplementationBegin(raiseWithReason, (NSString *expectedExceptionName,
                 exceptionCaught ? [exceptionCaught reason] : @""];
     });
     
-    failureMessageForNotTo(^NSString *{
+    failureMessageForNotTo(^NSString *(id actual){
         return [NSString stringWithFormat:@"expected: %@ (%@), got: %@ (%@)",
                 expectedExceptionName ? [NSString stringWithFormat:@"not %@", expectedExceptionName] : @"no exception",
                 expectedReason ? [NSString stringWithFormat:@"not '%@'", expectedReason] : @"no reason",

--- a/src/matchers/EXPMatchers+respondTo.m
+++ b/src/matchers/EXPMatchers+respondTo.m
@@ -2,25 +2,25 @@
 #import "EXPMatcherHelpers.h"
 
 EXPMatcherImplementationBegin(respondTo, (SEL expected)) {
-  BOOL actualIsNil = (actual == nil);
+  BOOL (^actualIsNil)(id actual) = ^BOOL(id actual){ return (actual == nil); };
   BOOL expectedIsNull = (expected == NULL);
 
-  prerequisite (^BOOL {
-    return !(actualIsNil || expectedIsNull);
+  prerequisite (^BOOL(id actual){
+    return !(actualIsNil(actual) || expectedIsNull);
   });
 
-  match(^BOOL {
+  match(^BOOL(id actual){
     return [actual respondsToSelector:expected];
   });
 
-  failureMessageForTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNull) return @"the selector is null";
     return [NSString stringWithFormat:@"expected: %@ to respond to %@", EXPDescribeObject(actual), NSStringFromSelector(expected)];
   });
 
-  failureMessageForNotTo(^NSString *{
-    if (actualIsNil) return @"the object is nil/null";
+  failureMessageForNotTo(^NSString *(id actual){
+    if (actualIsNil(actual)) return @"the object is nil/null";
     if (expectedIsNull) return @"the selector is null";
     return [NSString stringWithFormat:@"expected: %@ not to respond to %@", EXPDescribeObject(actual), NSStringFromSelector(expected)];
   });


### PR DESCRIPTION
The `EXPBlockDefinedMatcher` does not conform to the expected calling convention of `matches:`. A user would expect the value passed to `matches:` to be used in the matcher, but in the generated method body declared in `ExpectaSupport.h` the `actual` value is fetched a new by calling `self.actual`.

Although this currently works - it adds conceptual overhead and breaks if you want to work with collections - which is an open issue that some people appear to be working on.

As a result of this fix the `-[EXPExpect applyMathcer:to]` is now no longer useful as the `to` argument was only really being used as a flag to decide if there was actually an object available to test yet in async tests.

---

Fix broken calling convention for `-[EXPBlockDefinedMatcher matches:]` and Remove `-[EXPExpect applyMathcer:to]`

The summary of what is being changed is
- All block matchers are now called with `actual` rather than them asking their environment for `self.actual`
- `-[EXPExpect applyMathcer:to]` has been removed
- Any temp variables used in matchers that have their values derived from `actual` and were used within the `prerequisite`, `match`, `failureMessageForTo` and `failureMessageForNotTo` blocks have been wrapped in blocks to allow delayed execution as there is no longer an `actual` variable in the main scope of a matcher method.