### PR TITLE
Fix #93 - alias name conflicts

### DIFF
--- a/Expecta/ExpectaObject.h
+++ b/Expecta/ExpectaObject.h
@@ -5,6 +5,7 @@
 #define EXPMatcherInterface(matcherName, matcherArguments) _EXPMatcherInterface(matcherName, matcherArguments)
 #define EXPMatcherImplementationBegin(matcherName, matcherArguments) _EXPMatcherImplementationBegin(matcherName, matcherArguments)
 #define EXPMatcherImplementationEnd _EXPMatcherImplementationEnd
+#define EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments) _EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments)
 
 @interface Expecta : NSObject
 

--- a/Expecta/ExpectaSupport.h
+++ b/Expecta/ExpectaSupport.h
@@ -59,6 +59,15 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 } \
 @end
 
+#define _EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments) \
+EXPFixCategoriesBug(EXPMatcher##newMatcherName##Matcher); \
+@implementation EXPExpect (newMatcherName##Matcher) \
+@dynamic newMatcherName;\
+- (void(^) matcherArguments) newMatcherName { \
+  return [self oldMatcherName]; \
+}\
+@end
+
 #ifdef __cplusplus
 }
 #endif

--- a/Expecta/Matchers/EXPMatchers+beIdenticalTo.h
+++ b/Expecta/Matchers/EXPMatchers+beIdenticalTo.h
@@ -6,5 +6,5 @@ EXPMatcherInterface(beIdenticalTo, (void *expected)); // to aid code completion
 #if __has_feature(objc_arc)
 #define beIdenticalTo(expected) _beIdenticalTo((__bridge void*)expected)
 #else
-#define beIdenticalTo _beIdenticalTo
+#define beIdenticalTo(expected) _beIdenticalTo(expected)
 #endif

--- a/Expecta/Matchers/EXPMatchers+beIdenticalTo.m
+++ b/Expecta/Matchers/EXPMatchers+beIdenticalTo.m
@@ -1,7 +1,7 @@
 #import "EXPMatchers+equal.h"
 #import "EXPMatcherHelpers.h"
 
-EXPMatcherImplementationBegin(beIdenticalTo, (void *expected)) {
+EXPMatcherImplementationBegin(_beIdenticalTo, (void *expected)) {
   match(^BOOL{
     if(actual == expected) {
       return YES;

--- a/Expecta/Matchers/EXPMatchers+beInstanceOf.h
+++ b/Expecta/Matchers/EXPMatchers+beInstanceOf.h
@@ -1,7 +1,6 @@
 #import "Expecta.h"
 
-EXPMatcherInterface(beInstanceOf, (Class expected));
-
-#define beAnInstanceOf beInstanceOf
-#define beMemberOf beInstanceOf
-#define beAMemberOf beInstanceOf
+EXPMatcherInterface(beInstanceOf,   (Class expected));
+EXPMatcherInterface(beAnInstanceOf, (Class expected));
+EXPMatcherInterface(beMemberOf,     (Class expected));
+EXPMatcherInterface(beAMemberOf,    (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beInstanceOf.m
+++ b/Expecta/Matchers/EXPMatchers+beInstanceOf.m
@@ -25,3 +25,7 @@ EXPMatcherImplementationBegin(beInstanceOf, (Class expected)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(beAnInstanceOf, beInstanceOf, (Class expected));
+EXPMatcherAliasImplementation(beMemberOf,     beInstanceOf, (Class expected));
+EXPMatcherAliasImplementation(beAMemberOf,    beInstanceOf, (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beKindOf.h
+++ b/Expecta/Matchers/EXPMatchers+beKindOf.h
@@ -1,5 +1,4 @@
 #import "Expecta.h"
 
-EXPMatcherInterface(beKindOf, (Class expected));
-
-#define beAKindOf beKindOf
+EXPMatcherInterface(beKindOf,  (Class expected));
+EXPMatcherInterface(beAKindOf, (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beKindOf.m
+++ b/Expecta/Matchers/EXPMatchers+beKindOf.m
@@ -25,3 +25,5 @@ EXPMatcherImplementationBegin(beKindOf, (Class expected)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(beAKindOf, beKindOf, (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beNil.h
+++ b/Expecta/Matchers/EXPMatchers+beNil.h
@@ -1,5 +1,4 @@
 #import "Expecta.h"
 
 EXPMatcherInterface(beNil, (void));
-
-#define beNull beNil
+EXPMatcherInterface(beNull, (void));

--- a/Expecta/Matchers/EXPMatchers+beNil.m
+++ b/Expecta/Matchers/EXPMatchers+beNil.m
@@ -14,3 +14,5 @@ EXPMatcherImplementationBegin(beNil, (void)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(beNull, beNil, (void));

--- a/Expecta/Matchers/EXPMatchers+beSubclassOf.h
+++ b/Expecta/Matchers/EXPMatchers+beSubclassOf.h
@@ -1,5 +1,4 @@
 #import "Expecta.h"
 
-EXPMatcherInterface(beSubclassOf, (Class expected));
-
-#define beASubclassOf beSubclassOf
+EXPMatcherInterface(beSubclassOf,  (Class expected));
+EXPMatcherInterface(beASubclassOf, (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beSubclassOf.m
+++ b/Expecta/Matchers/EXPMatchers+beSubclassOf.m
@@ -25,3 +25,5 @@ EXPMatcherImplementationBegin(beSubclassOf, (Class expected)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(beASubclassOf, beSubclassOf, (Class expected));

--- a/Expecta/Matchers/EXPMatchers+beginWith.h
+++ b/Expecta/Matchers/EXPMatchers+beginWith.h
@@ -1,5 +1,4 @@
 #import "Expecta.h"
 
 EXPMatcherInterface(beginWith, (id expected));
-
-#define startWith beginWith
+EXPMatcherInterface(startWith, (id expected));

--- a/Expecta/Matchers/EXPMatchers+beginWith.m
+++ b/Expecta/Matchers/EXPMatchers+beginWith.m
@@ -47,3 +47,5 @@ EXPMatcherImplementationBegin(beginWith, (id expected)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(startWith, beginWith, (id expected));

--- a/Expecta/Matchers/EXPMatchers+haveCountOf.h
+++ b/Expecta/Matchers/EXPMatchers+haveCountOf.h
@@ -1,10 +1,10 @@
 #import "Expecta.h"
 
-EXPMatcherInterface(haveCountOf, (NSUInteger expected));
+EXPMatcherInterface(haveCountOf,   (NSUInteger expected));
+EXPMatcherInterface(haveCount,     (NSUInteger expected));
+EXPMatcherInterface(haveACountOf,  (NSUInteger expected));
+EXPMatcherInterface(haveLength,    (NSUInteger expected));
+EXPMatcherInterface(haveLengthOf,  (NSUInteger expected));
+EXPMatcherInterface(haveALengthOf, (NSUInteger expected));
 
-#define haveCount     haveCountOf
-#define haveACountOf  haveCountOf
-#define haveLength    haveCountOf
-#define haveLengthOf  haveCountOf
-#define haveALengthOf haveCountOf
-#define beEmpty()     haveCountOf(0)
+#define beEmpty() haveCountOf(0)

--- a/Expecta/Matchers/EXPMatchers+haveCountOf.m
+++ b/Expecta/Matchers/EXPMatchers+haveCountOf.m
@@ -34,3 +34,9 @@ EXPMatcherImplementationBegin(haveCountOf, (NSUInteger expected)) {
   });
 }
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(haveCount,     haveCountOf, (NSUInteger expected));
+EXPMatcherAliasImplementation(haveACountOf,  haveCountOf, (NSUInteger expected));
+EXPMatcherAliasImplementation(haveLength,    haveCountOf, (NSUInteger expected));
+EXPMatcherAliasImplementation(haveLengthOf,  haveCountOf, (NSUInteger expected));
+EXPMatcherAliasImplementation(haveALengthOf, haveCountOf, (NSUInteger expected));

--- a/Expecta/Matchers/EXPMatchers+postNotification.h
+++ b/Expecta/Matchers/EXPMatchers+postNotification.h
@@ -1,5 +1,4 @@
 #import "Expecta.h"
 
 EXPMatcherInterface(postNotification, (id expectedNotification));
-
-#define notify postNotification
+EXPMatcherInterface(notify, (id expectedNotification));

--- a/Expecta/Matchers/EXPMatchers+postNotification.m
+++ b/Expecta/Matchers/EXPMatchers+postNotification.m
@@ -84,3 +84,5 @@ EXPMatcherImplementationBegin(postNotification, (id expected)){
 }
 
 EXPMatcherImplementationEnd
+
+EXPMatcherAliasImplementation(notify, postNotification, (id expectedNotification))

--- a/Tests/DynamicPredicateMatcherTest.m
+++ b/Tests/DynamicPredicateMatcherTest.m
@@ -19,7 +19,7 @@
 @end
 
 EXPMatcherInterface(isTurnedOn, (void));
-#define beTurnedOn isTurnedOn
+EXPMatcherInterface(beTurnedOn, (void));
 
 @interface DynamicPredicateMatcherTest : XCTestCase
 @end
@@ -40,3 +40,5 @@ EXPMatcherInterface(isTurnedOn, (void));
 }
 
 @end
+
+EXPMatcherAliasImplementation(beTurnedOn, isTurnedOn, (void));

--- a/Tests/Matchers/EXPMatchers+beginWithTest.m
+++ b/Tests/Matchers/EXPMatchers+beginWithTest.m
@@ -105,4 +105,8 @@
   assertFail(test_expect(object).notTo.beginWith(sampleSet), ([NSString stringWithFormat:@"<NSObject: %p> and {(Bar, 1, baz)} are not instances of one of NSString, NSArray, or NSOrderedSet", object]));
 }
 
+- (void)test_startWith {
+  assertPass(test_expect(@"Foobar").startWith(@"Foo"));
+}
+
 @end

--- a/Tests/Matchers/EXPMatchers+haveCountOfTest.m
+++ b/Tests/Matchers/EXPMatchers+haveCountOfTest.m
@@ -55,4 +55,24 @@
   assertFail(test_expect(object).toNot.haveCountOf(2), errorMessage);
 }
 
+- (void)test_haveCount {
+  assertPass(test_expect(array).haveCount(3));
+}
+
+- (void)test_haveACountOf {
+  assertPass(test_expect(array).haveACountOf(3));
+}
+
+- (void)test_haveLength {
+  assertPass(test_expect(array).haveLength(3));
+}
+
+- (void)test_haveLengthOf {
+  assertPass(test_expect(array).haveLengthOf(3));
+}
+
+- (void)test_haveALengthOf {
+  assertPass(test_expect(array).haveALengthOf(3));
+}
+
 @end


### PR DESCRIPTION
Using #define to create aliases leads to the potential of naming collisions. This commit introduces a new macro that just calls through to the aliased method