### PR TITLE
Test for notification equality manually

### DIFF
--- a/src/matchers/EXPMatchers+postNotification.m
+++ b/src/matchers/EXPMatchers+postNotification.m
@@ -1,5 +1,28 @@
 #import "EXPMatchers+postNotification.h"
 
+@implementation NSNotification (EXPEquality)
+
+- (BOOL)exp_isFunctionallyEqualTo:(NSNotification *)otherNotification
+{
+  if (![otherNotification isKindOfClass:[NSNotification class]]) return NO;
+
+  BOOL namesMatch = [otherNotification.name isEqualToString:self.name];
+
+  BOOL objectsMatch = YES;
+  if (otherNotification.object || self.object) {
+    objectsMatch = [otherNotification.object isEqual:self.object];
+  }
+
+  BOOL userInfoMatches = YES;
+  if (otherNotification.userInfo || self.userInfo) {
+    userInfoMatches = [otherNotification.userInfo isEqual:self.userInfo];
+  }
+
+  return (namesMatch && objectsMatch && userInfoMatches);
+}
+
+@end
+
 EXPMatcherImplementationBegin(postNotification, (id expected)){
   BOOL actualIsNil = (actual == nil);
   BOOL expectedIsNil = (expected == nil);
@@ -23,7 +46,7 @@ EXPMatcherImplementationBegin(postNotification, (id expected)){
 
     observer = [[NSNotificationCenter defaultCenter] addObserverForName:expectedName object:nil queue:nil usingBlock:^(NSNotification *note){
       if (isNotification) {
-        expectedNotificationOccurred |= [expected isEqual:note];
+        expectedNotificationOccurred |= [expected exp_isFunctionallyEqualTo:note];
       }else{
         expectedNotificationOccurred = YES;
       }

--- a/test/matchers/EXPMatchers+postNotificationTest.m
+++ b/test/matchers/EXPMatchers+postNotificationTest.m
@@ -48,6 +48,12 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
   }).to.postNotification(@"testNotification1"));
 
+  NSObject *object = [NSObject new];
+
+  assertPass(test_expect(^{
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:object];
+  }).to.notify([NSNotification notificationWithName:@"testNotification1" object:object]));
+
   assertPass(test_expect(^{
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_current_queue(), ^{
       [[NSNotificationCenter defaultCenter] postNotificationName:@"NotificationName" object:nil];


### PR DESCRIPTION
`NSNotification` uses pointer equality when using `isEqual:`. This means that
passing an instance of `NSNotification` to the `notify` matcher is essentially
pointless, as it will only pass if you're storing the instance somewhere. This
change makes it so that the matcher checks for
`name`, `object`, and `userInfo` equality, instead of pointer equality. This
makes the matcher much more useful.