### PR TITLE
Rename `notify` to `postNotification`

### DIFF
--- a/Expecta.xcodeproj/project.pbxproj
+++ b/Expecta.xcodeproj/project.pbxproj
@@ -13,13 +13,13 @@
 		2546A95F16629D500078E044 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A95B16629D4F0078E044 /* EXPMatchers+raiseWithReason.m */; };
 		2546A96216629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A96116629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m */; };
 		2546A96316629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A96116629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m */; };
-		2706C0C3183F25870053E3CF /* EXPMatchers+notify.h in Headers */ = {isa = PBXBuildFile; fileRef = 27B6192A182F4D3F0075C95F /* EXPMatchers+notify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2706C0C4183F25900053E3CF /* EXPMatchers+notify.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192B182F4D3F0075C95F /* EXPMatchers+notify.m */; };
-		2706C0C5183F26580053E3CF /* EXPMatchers+notifyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+notifyTest.m */; };
-		2706C0C6183F26590053E3CF /* EXPMatchers+notifyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+notifyTest.m */; };
-		27B6192C182F4D3F0075C95F /* EXPMatchers+notify.h in Headers */ = {isa = PBXBuildFile; fileRef = 27B6192A182F4D3F0075C95F /* EXPMatchers+notify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27B6192D182F4D3F0075C95F /* EXPMatchers+notify.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192B182F4D3F0075C95F /* EXPMatchers+notify.m */; };
-		27B61930182F4DF30075C95F /* EXPMatchers+notifyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+notifyTest.m */; };
+		2706C0C3183F25870053E3CF /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 27B6192A182F4D3F0075C95F /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2706C0C4183F25900053E3CF /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192B182F4D3F0075C95F /* EXPMatchers+postNotification.m */; };
+		2706C0C5183F26580053E3CF /* EXPMatchers+postNotificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+postNotificationTest.m */; };
+		2706C0C6183F26590053E3CF /* EXPMatchers+postNotificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+postNotificationTest.m */; };
+		27B6192C182F4D3F0075C95F /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 27B6192A182F4D3F0075C95F /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27B6192D182F4D3F0075C95F /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192B182F4D3F0075C95F /* EXPMatchers+postNotification.m */; };
+		27B61930182F4DF30075C95F /* EXPMatchers+postNotificationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27B6192F182F4DF30075C95F /* EXPMatchers+postNotificationTest.m */; };
 		27B61931182F5A700075C95F /* EXPMatchers+respondToTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 77F6231C182418F10004F628 /* EXPMatchers+respondToTest.m */; };
 		4913B4C71411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4913B4C61411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m */; };
 		4913B4C81411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4913B4C61411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m */; };
@@ -290,9 +290,9 @@
 		2546A95A16629D4F0078E044 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
 		2546A95B16629D4F0078E044 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
 		2546A96116629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+raiseWithReasonTest.m"; sourceTree = "<group>"; };
-		27B6192A182F4D3F0075C95F /* EXPMatchers+notify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXPMatchers+notify.h"; sourceTree = "<group>"; };
-		27B6192B182F4D3F0075C95F /* EXPMatchers+notify.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+notify.m"; sourceTree = "<group>"; };
-		27B6192F182F4DF30075C95F /* EXPMatchers+notifyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+notifyTest.m"; sourceTree = "<group>"; };
+		27B6192A182F4D3F0075C95F /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
+		27B6192B182F4D3F0075C95F /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
+		27B6192F182F4DF30075C95F /* EXPMatchers+postNotificationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+postNotificationTest.m"; sourceTree = "<group>"; };
 		4913B4C61411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+beGreaterThanTest.m"; sourceTree = "<group>"; };
 		4913B4CA1411E18A00040ECB /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
 		4913B4CB1411E18A00040ECB /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
@@ -546,8 +546,8 @@
 				770D4426187B2A170031D46C /* EXPMatchers+endWith.m */,
 				770D4417187B29830031D46C /* EXPMatchers+beginWith.h */,
 				770D4418187B29830031D46C /* EXPMatchers+beginWith.m */,
-				27B6192A182F4D3F0075C95F /* EXPMatchers+notify.h */,
-				27B6192B182F4D3F0075C95F /* EXPMatchers+notify.m */,
+				27B6192A182F4D3F0075C95F /* EXPMatchers+postNotification.h */,
+				27B6192B182F4D3F0075C95F /* EXPMatchers+postNotification.m */,
 				E9ACDF5413B2DDC60010F4D7 /* EXPMatchers.h */,
 				E9ACDF4413B2DDC60010F4D7 /* EXPMatcherHelpers.h */,
 				E9ACDF4513B2DDC60010F4D7 /* EXPMatcherHelpers.m */,
@@ -620,7 +620,7 @@
 			children = (
 				770D4421187B29E00031D46C /* EXPMatchers+endWithTest.m */,
 				770D441D187B299E0031D46C /* EXPMatchers+beginWithTest.m */,
-				27B6192F182F4DF30075C95F /* EXPMatchers+notifyTest.m */,
+				27B6192F182F4DF30075C95F /* EXPMatchers+postNotificationTest.m */,
 				61740D841425689A00091DDF /* EXPMatchers+beInTheRangeOfTest.m */,
 				E942971113B45ADD0038708B /* EXPMatchers+beIdenticalToTest.m */,
 				E9ACDF7613B2DEB70010F4D7 /* EXPMatchers+beInstanceOfTest.m */,
@@ -699,7 +699,7 @@
 				E930680A13B2E83500EA26FF /* EXPMatchers.h in Headers */,
 				E930680B13B2E83800EA26FF /* EXPMatcherHelpers.h in Headers */,
 				E930680D13B2E83E00EA26FF /* EXPMatchers+beFalsy.h in Headers */,
-				27B6192C182F4D3F0075C95F /* EXPMatchers+notify.h in Headers */,
+				27B6192C182F4D3F0075C95F /* EXPMatchers+postNotification.h in Headers */,
 				E930680F13B2E84400EA26FF /* EXPMatchers+beInstanceOf.h in Headers */,
 				E930681113B2E84900EA26FF /* EXPMatchers+beKindOf.h in Headers */,
 				E930681313B2E84E00EA26FF /* EXPMatchers+beNil.h in Headers */,
@@ -762,7 +762,7 @@
 				E1EB1BC313BEA1BE00E4C93B /* EXPDoubleTuple.h in Headers */,
 				E1EB1BC713BEA1BE00E4C93B /* EXPFloatTuple.h in Headers */,
 				63F6F355150A542D009E1BC3 /* EXPMatchers+beCloseTo.h in Headers */,
-				2706C0C3183F25870053E3CF /* EXPMatchers+notify.h in Headers */,
+				2706C0C3183F25870053E3CF /* EXPMatchers+postNotification.h in Headers */,
 				63B349DD15135C8800C955DC /* EXPMatchers+haveCountOf.h in Headers */,
 				E9D3DF15157A7EB40054978E /* EXPMatchers+raise.h in Headers */,
 				2546A95C16629D500078E044 /* EXPMatchers+raiseWithReason.h in Headers */,
@@ -978,7 +978,7 @@
 				9C44170B17FF409D00978F09 /* EXPMatchers+beInTheRangeOfTest.m in Sources */,
 				77F6231F182418F10004F628 /* EXPMatchers+respondToTest.m in Sources */,
 				9C44171417FF409D00978F09 /* EXPMatchers+raiseTest.m in Sources */,
-				2706C0C5183F26580053E3CF /* EXPMatchers+notifyTest.m in Sources */,
+				2706C0C5183F26580053E3CF /* EXPMatchers+postNotificationTest.m in Sources */,
 				9C44171317FF409D00978F09 /* EXPMatchers+equalTest.m in Sources */,
 				9C44170F17FF409D00978F09 /* EXPMatchers+beNilTest.m in Sources */,
 				770D4424187B29E00031D46C /* EXPMatchers+endWithTest.m in Sources */,
@@ -999,7 +999,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E930680413B2E81C00EA26FF /* EXPExpect.m in Sources */,
-				27B6192D182F4D3F0075C95F /* EXPMatchers+notify.m in Sources */,
+				27B6192D182F4D3F0075C95F /* EXPMatchers+postNotification.m in Sources */,
 				E930680613B2E82100EA26FF /* EXPUnsupportedObject.m in Sources */,
 				E930680813B2E82500EA26FF /* NSValue+Expecta.m in Sources */,
 				E930680C13B2E83A00EA26FF /* EXPMatcherHelpers.m in Sources */,
@@ -1061,7 +1061,7 @@
 				E9AFC43B13C482D3006B4F2A /* AsynchronousTestingTest.m in Sources */,
 				AE0E76FD13FF37D6009AF5D8 /* EXPMatchers+beLessThanTest.m in Sources */,
 				AEBA779614055CA2001690B6 /* EXPMatchers+beLessThanOrEqualToTest.m in Sources */,
-				27B61930182F4DF30075C95F /* EXPMatchers+notifyTest.m in Sources */,
+				27B61930182F4DF30075C95F /* EXPMatchers+postNotificationTest.m in Sources */,
 				4913B4C81411E01A00040ECB /* EXPMatchers+beGreaterThanTest.m in Sources */,
 				4913B4D21411E2DA00040ECB /* EXPMatchers+beGreaterThanOrEqualToTest.m in Sources */,
 				61740D861425689A00091DDF /* EXPMatchers+beInTheRangeOfTest.m in Sources */,
@@ -1104,7 +1104,7 @@
 				4913B4D71411E45800040ECB /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
 				617BC21A142579C500D6C27C /* EXPMatchers+beInTheRangeOf.m in Sources */,
 				63F6F34E150A5172009E1BC3 /* EXPMatchers+beLessThan.m in Sources */,
-				2706C0C4183F25900053E3CF /* EXPMatchers+notify.m in Sources */,
+				2706C0C4183F25900053E3CF /* EXPMatchers+postNotification.m in Sources */,
 				63F6F357150A542D009E1BC3 /* EXPMatchers+beCloseTo.m in Sources */,
 				77F622FF182405D80004F628 /* EXPMatchers+respondTo.m in Sources */,
 				63B349DF15135C8800C955DC /* EXPMatchers+haveCountOf.m in Sources */,
@@ -1149,7 +1149,7 @@
 				A305756E1520C5B200DA19BD /* CustomMatcherImplementationsTest.m in Sources */,
 				770D441E187B299E0031D46C /* EXPMatchers+beginWithTest.m in Sources */,
 				A30575A91520F5FE00DA19BD /* DynamicPredicateMatcherTest.m in Sources */,
-				2706C0C6183F26590053E3CF /* EXPMatchers+notifyTest.m in Sources */,
+				2706C0C6183F26590053E3CF /* EXPMatchers+postNotificationTest.m in Sources */,
 				E9D3DF0E157A7B7E0054978E /* EXPMatchers+raiseTest.m in Sources */,
 				E9D3DF1B157A8AC30054978E /* EXPMatchers+beCloseToTest.m in Sources */,
 				541B02B11805E24C000DA87C /* EXPMatchers+conformToTest.m in Sources */,

--- a/src/matchers/EXPMatchers+notify.h
+++ b/src/matchers/EXPMatchers+notify.h
@@ -1,4 +1,0 @@
-#import "Expecta.h"
-
-EXPMatcherInterface(notify, (id expectedNotification));
-

--- a/src/matchers/EXPMatchers+postNotification.h
+++ b/src/matchers/EXPMatchers+postNotification.h
@@ -1,0 +1,5 @@
+#import "Expecta.h"
+
+EXPMatcherInterface(postNotification, (id expectedNotification));
+
+#define notify postNotification

--- a/src/matchers/EXPMatchers+postNotification.m
+++ b/src/matchers/EXPMatchers+postNotification.m
@@ -1,15 +1,15 @@
-#import "EXPMatchers+notify.h"
+#import "EXPMatchers+postNotification.h"
 
-EXPMatcherImplementationBegin(notify, (id expected)){
+EXPMatcherImplementationBegin(postNotification, (id expected)){
   BOOL actualIsNil = (actual == nil);
   BOOL expectedIsNil = (expected == nil);
   BOOL isNotification = [expected isKindOfClass:[NSNotification class]];
   BOOL isName = [expected isKindOfClass:[NSString class]];
-  
+
   __block NSString *expectedName;
   __block BOOL expectedNotificationOccurred = NO;
   __block id observer;
-  
+
   prerequisite(^BOOL{
     expectedNotificationOccurred = NO;
     if (actualIsNil || expectedIsNil) return NO;
@@ -20,7 +20,7 @@ EXPMatcherImplementationBegin(notify, (id expected)){
     }else{
       return NO;
     }
-    
+
     observer = [[NSNotificationCenter defaultCenter] addObserverForName:expectedName object:nil queue:nil usingBlock:^(NSNotification *note){
       if (isNotification) {
         expectedNotificationOccurred |= [expected isEqual:note];
@@ -31,14 +31,14 @@ EXPMatcherImplementationBegin(notify, (id expected)){
     ((EXPBasicBlock)actual)();
     return YES;
   });
-  
+
   match(^BOOL{
     if(expectedNotificationOccurred) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
     }
     return expectedNotificationOccurred;
   });
-  
+
   failureMessageForTo(^NSString *{
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];
@@ -48,7 +48,7 @@ EXPMatcherImplementationBegin(notify, (id expected)){
     if(!(isNotification || isName)) return @"the actual value is not a notification or string";
     return [NSString stringWithFormat:@"expected: %@, got: none",expectedName];
   });
-  
+
   failureMessageForNotTo(^NSString *{
     if (observer) {
       [[NSNotificationCenter defaultCenter] removeObserver:observer];

--- a/src/matchers/EXPMatchers.h
+++ b/src/matchers/EXPMatchers.h
@@ -19,6 +19,6 @@
 #import "EXPMatchers+raise.h"
 #import "EXPMatchers+raiseWithReason.h"
 #import "EXPMatchers+respondTo.h"
-#import "EXPMatchers+notify.h"
+#import "EXPMatchers+postNotification.h"
 #import "EXPMatchers+beginWith.h"
 #import "EXPMatchers+endWith.h"

--- a/test/matchers/EXPMatchers+postNotificationTest.m
+++ b/test/matchers/EXPMatchers+postNotificationTest.m
@@ -1,124 +1,121 @@
 #import "TestHelper.h"
 
-@interface EXPMatchers_notifyTest : TEST_SUPERCLASS
+@interface EXPMatchers_postNotificationTest : TEST_SUPERCLASS
 @end
 
-@implementation EXPMatchers_notifyTest
+@implementation EXPMatchers_postNotificationTest
 
-- (void)test_notify {
+- (void)test_postNotification {
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).to.notify(@"testNotification1"));
-  
+  }).to.postNotification(@"testNotification1"));
+
   NSNotification *n1 = [[NSNotification alloc] initWithName:@"testNotification2" object:self userInfo:nil];
-  
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotification:n1];
-  }).to.notify(n1));
+  }).to.postNotification(n1));
 
   NSNotification *n2 = [[NSNotification alloc] initWithName:@"testNotification2" object:self userInfo:@{@"test" : @"value2"}];
 
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:self userInfo:@{@"test" : @"value2"}];
-  }).to.notify(n2));
-  
+  }).to.postNotification(n2));
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotification:n1];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:self userInfo:@{@"test" : @"value"}];
-  }).to.notify(n1));
-  
+  }).to.postNotification(n1));
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:nil];
-  }).to.notify(@"testNotification1"));
-    
+  }).to.postNotification(@"testNotification1"));
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).to.notify(@"testNotification1"));
-    
+  }).to.postNotification(@"testNotification1"));
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:nil];
-  }).to.notify(@"testNotification1"));
+  }).to.postNotification(@"testNotification1"));
 
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).to.notify(@"testNotification1"));
-  
+  }).to.postNotification(@"testNotification1"));
+
   assertPass(test_expect(^{
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_current_queue(), ^{
       [[NSNotificationCenter defaultCenter] postNotificationName:@"NotificationName" object:nil];
     });
-  }).will.notify(@"NotificationName"));
-  
+  }).will.postNotification(@"NotificationName"));
+
   assertFail(test_expect(^{
     // no notification
-  }).to.notify(@"testNotification2"),
+  }).to.postNotification(@"testNotification2"),
              @"expected: testNotification2, got: none");
-  
-  assertFail(test_expect(nil).to.notify(@"testNotification"),
+
+  assertFail(test_expect(nil).to.postNotification(@"testNotification"),
              @"the actual value is nil/null");
-  
+
   assertFail(test_expect(^{
     // no notification
-  }).to.notify(nil),
+  }).to.postNotification(nil),
              @"the expected value is nil/null");
-  
+
   assertFail(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).to.notify(@"testNotification2"),
+  }).to.postNotification(@"testNotification2"),
              @"expected: testNotification2, got: none");
-  
+
   assertFail(test_expect(^{
     // not doing anything
-  }).to.notify([[NSObject alloc] init]), @"the actual value is not a notification or string");
-  
+  }).to.postNotification([[NSObject alloc] init]), @"the actual value is not a notification or string");
+
   assertFail(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification2" object:self userInfo:@{@"test" : @"value"}];
-  }).to.notify(n2), @"expected: testNotification2, got: none");
-  
+  }).to.postNotification(n2), @"expected: testNotification2, got: none");
 }
 
-- (void)test_toNot_notify {
+- (void)test_toNot_postNotification {
   assertPass(test_expect(^{
     // no notification
-  }).notTo.notify(@"testExpectaNotification1"));
-  
+  }).notTo.postNotification(@"testExpectaNotification1"));
+
   assertFail(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).toNot.notify(@"testNotification1"),
+  }).toNot.postNotification(@"testNotification1"),
              @"expected: none, got: testNotification1");
-  
+
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testNotification1" object:nil];
-  }).notTo.notify(@"testNotification2"));
-  
+  }).notTo.postNotification(@"testNotification2"));
+
   NSNotification *n1 = [[NSNotification alloc] initWithName:@"testNotification4" object:self userInfo:nil];
   NSNotification *n2 = [[NSNotification alloc] initWithName:@"testNotification4" object:nil userInfo:nil];
   assertPass(test_expect(^{
     [[NSNotificationCenter defaultCenter] postNotification:n1];
-  }).toNot.notify(n2));
-  
+  }).toNot.postNotification(n2));
+
   assertPass(test_expect(^{
     // no notification
-  }).willNot.notify(@"NotificationName"));
-  
-  
-  assertFail(test_expect(nil).toNot.notify(@"testNotification"),
+  }).willNot.postNotification(@"NotificationName"));
+
+  assertFail(test_expect(nil).toNot.postNotification(@"testNotification"),
              @"the actual value is nil/null");
-  
+
   assertFail(test_expect(^{
     // no notification
-  }).toNot.notify(nil),
+  }).toNot.postNotification(nil),
              @"the expected value is nil/null");
-  
+
   assertFail(test_expect(^{
     // no notification
-  }).toNot.notify([[NSObject alloc] init]), @"the actual value is not a notification or string");
-  
+  }).toNot.postNotification([[NSObject alloc] init]), @"the actual value is not a notification or string");
 }
 
 @end


### PR DESCRIPTION
This matcher was pretty poorly named, in my opinion. It makes much more sense
for the matcher to be called `postNotification`, as it reads better in a
sentence. I've aliased `notify` to `postNotification` to preserve backwards
compatibility.