### PR TITLE
fix for comparison of NSNumber and NSDecimalNumber

### DIFF
--- a/src/matchers/EXPMatchers+equal.m
+++ b/src/matchers/EXPMatchers+equal.m
@@ -6,8 +6,15 @@ EXPMatcherImplementationBegin(_equal, (id expected)) {
     if((actual == expected) || [actual isEqual:expected]) {
       return YES;
     } else if([actual isKindOfClass:[NSNumber class]] && [expected isKindOfClass:[NSNumber class]]) {
-      if(EXPIsNumberFloat((NSNumber *)actual) || EXPIsNumberFloat((NSNumber *)expected)) {
-        return [(NSNumber *)actual floatValue] == [(NSNumber *)expected floatValue];
+      if([actual isKindOfClass:[NSDecimalNumber class]] || [expected isKindOfClass:[NSDecimalNumber class]]) {
+        NSDecimalNumber *actualDecimalNumber = [NSDecimalNumber decimalNumberWithDecimal:[(NSNumber *) actual decimalValue]];
+        NSDecimalNumber *expectedDecimalNumber = [NSDecimalNumber decimalNumberWithDecimal:[(NSNumber *) expected decimalValue]];
+        return [actualDecimalNumber isEqualToNumber:expectedDecimalNumber];
+      }
+      else {
+        if(EXPIsNumberFloat((NSNumber *)actual) || EXPIsNumberFloat((NSNumber *)expected)) {
+          return [(NSNumber *)actual floatValue] == [(NSNumber *)expected floatValue];
+        }
       }
     }
     return NO;

--- a/test/matchers/EXPMatchers+equalTest.m
+++ b/test/matchers/EXPMatchers+equalTest.m
@@ -172,6 +172,14 @@
   assertPass(test_expect(block).toNot.equal(block2));
 }
 
+- (void)test_equal_decimal_to_number {
+  NSDecimalNumber *decimalNumber=[NSDecimalNumber decimalNumberWithString:@"1.07"];
+  NSNumber *number = @1.07;
+  assertPass(test_expect(decimalNumber).equal(number));
+  assertPass(test_expect(number).equal(decimalNumber));
+  assertPass(test_expect(@1.071).toNot.equal(decimalNumber));
+}
+
 typedef struct SomeFloatPair {
     float x;
     float y;


### PR DESCRIPTION
it is a fix for issue [#118](https://github.com/specta/expecta/issues/118), where .equal() provides false negative results when testing equality of a NSDecimalNumber and a NSNumber