### PR TITLE
Fix #110 - issue with beSupersetOf when compare mutable and immutable co...

### DIFF
--- a/Expecta.xcodeproj/project.pbxproj
+++ b/Expecta.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1137E3F6805E8DD7599ADCA8 /* EXPMatchers+beSupersetOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C6B1F5180CAD5100E13146 /* EXPMatchers+beSupersetOfTest.m */; };
+		1137E875D17A9C593D6C71C3 /* EXPMatchers+beSupersetOfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C6B1F5180CAD5100E13146 /* EXPMatchers+beSupersetOfTest.m */; };
 		2546A95C16629D500078E044 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 2546A95A16629D4F0078E044 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2546A95D16629D500078E044 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 2546A95A16629D4F0078E044 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2546A95E16629D500078E044 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A95B16629D4F0078E044 /* EXPMatchers+raiseWithReason.m */; };
@@ -1234,6 +1236,7 @@
 				770D4420187B299E0031D46C /* EXPMatchers+beginWithTest.m in Sources */,
 				9C44171A17FF409D00978F09 /* EXPMatchers+beLessThanTest.m in Sources */,
 				9C44171C17FF409D00978F09 /* EXPMatchers+beCloseToTest.m in Sources */,
+				1137E875D17A9C593D6C71C3 /* EXPMatchers+beSupersetOfTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1314,6 +1317,7 @@
 				E9D3DF0F157A7B7E0054978E /* EXPMatchers+raiseTest.m in Sources */,
 				E9D3DF1C157A8AC30054978E /* EXPMatchers+beCloseToTest.m in Sources */,
 				2546A96316629DF70078E044 /* EXPMatchers+raiseWithReasonTest.m in Sources */,
+				1137E3F6805E8DD7599ADCA8 /* EXPMatchers+beSupersetOfTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expecta/Matchers/EXPMatchers+beSupersetOf.m
+++ b/Expecta/Matchers/EXPMatchers+beSupersetOf.m
@@ -7,9 +7,14 @@ EXPMatcherImplementationBegin(beSupersetOf, (id subset)) {
   // For some instances the isKindOfClass: method returns false, even though
   // they are both actually dictionaries. e.g. Comparing a NSCFDictionary and a
   // NSDictionary.
-  BOOL bothAreDictionaries = [actual isKindOfClass:[NSDictionary class]] && [subset isKindOfClass:[NSDictionary class]];
+  // Or in cases when you compare NSMutableArray (which implementation is __NSArrayM:NSMutableArray:NSArray)
+  // and NSArray (which implementation is __NSArrayI:NSArray)
+  BOOL bothAreIdenticalCollectionClasses = ([actual isKindOfClass:[NSDictionary class]] && [subset isKindOfClass:[NSDictionary class]]) ||
+        ([actual isKindOfClass:[NSArray class]] && [subset isKindOfClass:[NSArray class]]) ||
+        ([actual isKindOfClass:[NSSet class]] && [subset isKindOfClass:[NSSet class]]) ||
+        ([actual isKindOfClass:[NSOrderedSet class]] && [subset isKindOfClass:[NSOrderedSet class]]);
 
-  BOOL classMatches = bothAreDictionaries || [subset isKindOfClass:[actual class]];
+  BOOL classMatches = bothAreIdenticalCollectionClasses || [subset isKindOfClass:[actual class]];
 
   prerequisite(^BOOL{
     return actualIsCompatible && !subsetIsNil && classMatches;

--- a/Tests/Matchers/EXPMatchers+beSupersetOfTest.m
+++ b/Tests/Matchers/EXPMatchers+beSupersetOfTest.m
@@ -24,11 +24,21 @@
 }
 
 - (void)test_beSupersetOf {
-  assertPass(test_expect(array).beSupersetOf([NSArray arrayWithObject:@"foo"]));
+  assertPass(test_expect(array).beSupersetOf(@[@"foo"]));
   assertPass(test_expect(set).beSupersetOf([NSSet setWithObject:@"bar"]));
   assertPass(test_expect(orderedSet).beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"]));
-  assertPass(test_expect(dictionary).beSupersetOf([NSDictionary dictionaryWithObject:@2 forKey:@"bar"]));
-  assertPass(test_expect(json).beSupersetOf([NSDictionary dictionaryWithObject:@2 forKey:@"bar"]));
+  assertPass(test_expect(dictionary).beSupersetOf(@{@"bar" : @2}));
+  assertPass(test_expect(json).beSupersetOf(@{@"bar" : @2}));
+
+  assertPass(test_expect(array).beSupersetOf(@[@"foo"].mutableCopy));
+  assertPass(test_expect(set).beSupersetOf([NSSet setWithObject:@"bar"].mutableCopy));
+  assertPass(test_expect(orderedSet).beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"].mutableCopy));
+  assertPass(test_expect(dictionary).beSupersetOf(@{@"bar" : @2}.mutableCopy));
+
+  assertPass(test_expect(array.mutableCopy).beSupersetOf(@[@"foo"]));
+  assertPass(test_expect(set.mutableCopy).beSupersetOf([NSSet setWithObject:@"bar"]));
+  assertPass(test_expect(orderedSet.mutableCopy).beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"]));
+  assertPass(test_expect(dictionary.mutableCopy).beSupersetOf(@{@"bar" : @2}));
 
   assertPass(test_expect(array).beSupersetOf(array));
   assertPass(test_expect(set).beSupersetOf(set));
@@ -55,7 +65,17 @@
   assertFail(test_expect(array).notTo.beSupersetOf(@[ @"foo"] ), @"expected (foo, bar, baz) not to be a superset of (foo)");
   assertFail(test_expect(set).notTo.beSupersetOf([NSSet setWithObject:@"bar"]), @"expected {(foo, bar)} not to be a superset of {(bar)}");
   assertFail(test_expect(orderedSet).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"]), @"expected {(foo, bar, baz)} not to be a superset of {(baz)}");
-    assertFail(test_expect(dictionary).notTo.beSupersetOf(@{ @"bar" : @2 }), @"expected {foo = 1; bar = 2;} not to be a superset of {bar = 2;}");
+  assertFail(test_expect(dictionary).notTo.beSupersetOf(@{ @"bar" : @2 }), @"expected {foo = 1; bar = 2;} not to be a superset of {bar = 2;}");
+
+  assertFail(test_expect(array).notTo.beSupersetOf(@[ @"foo"].mutableCopy ), @"expected (foo, bar, baz) not to be a superset of (foo)");
+  assertFail(test_expect(set).notTo.beSupersetOf([NSSet setWithObject:@"bar"].mutableCopy), @"expected {(foo, bar)} not to be a superset of {(bar)}");
+  assertFail(test_expect(orderedSet).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"].mutableCopy), @"expected {(foo, bar, baz)} not to be a superset of {(baz)}");
+  assertFail(test_expect(dictionary).notTo.beSupersetOf(@{ @"bar" : @2 }.mutableCopy), @"expected {foo = 1; bar = 2;} not to be a superset of {bar = 2;}");
+
+  assertFail(test_expect(array.mutableCopy).notTo.beSupersetOf(@[ @"foo"] ), @"expected (foo, bar, baz) not to be a superset of (foo)");
+  assertFail(test_expect(set.mutableCopy).notTo.beSupersetOf([NSSet setWithObject:@"bar"]), @"expected {(foo, bar)} not to be a superset of {(bar)}");
+  assertFail(test_expect(orderedSet.mutableCopy).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"baz"]), @"expected {(foo, bar, baz)} not to be a superset of {(baz)}");
+  assertFail(test_expect(dictionary.mutableCopy).notTo.beSupersetOf(@{ @"bar" : @2 }), @"expected {foo = 1; bar = 2;} not to be a superset of {bar = 2;}");
 
   assertFail(test_expect(array).notTo.beSupersetOf(array), @"expected (foo, bar, baz) not to be a superset of (foo, bar, baz)");
   assertFail(test_expect(set).notTo.beSupersetOf(set), @"expected {(foo, bar)} not to be a superset of {(foo, bar)}");
@@ -67,11 +87,21 @@
   assertFail(test_expect(orderedSet).notTo.beSupersetOf([NSOrderedSet orderedSet]), @"expected {(foo, bar, baz)} not to be a superset of {()}");
   assertFail(test_expect(dictionary).notTo.beSupersetOf([NSDictionary dictionary]), @"expected {foo = 1; bar = 2;} not to be a superset of {}");
 
-  assertPass(test_expect(array).notTo.beSupersetOf(@[ @"xyz" ]);
+  assertPass(test_expect(array).notTo.beSupersetOf(@[ @"xyz" ]));
   assertPass(test_expect(set).notTo.beSupersetOf([NSSet setWithObject:@"xyz"]));
   assertPass(test_expect(orderedSet).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"xyz"]));
   assertPass(test_expect(dictionary).notTo.beSupersetOf(@{ @"xyz" : @2 }));
-  assertPass(test_expect(json).notTo.beSupersetOf([NSDictionary dictionaryWithObject:@2 forKey:@"xyz"]));
+  assertPass(test_expect(json).notTo.beSupersetOf(@{@"xyz" : @2}));
+
+  assertPass(test_expect(array).notTo.beSupersetOf(@[ @"xyz" ].mutableCopy));
+  assertPass(test_expect(set).notTo.beSupersetOf([NSSet setWithObject:@"xyz"].mutableCopy));
+  assertPass(test_expect(orderedSet).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"xyz"].mutableCopy));
+  assertPass(test_expect(dictionary).notTo.beSupersetOf(@{ @"xyz" : @2 }.mutableCopy));
+
+  assertPass(test_expect(array.mutableCopy).notTo.beSupersetOf(@[ @"xyz" ]));
+  assertPass(test_expect(set.mutableCopy).notTo.beSupersetOf([NSSet setWithObject:@"xyz"]));
+  assertPass(test_expect(orderedSet.mutableCopy).notTo.beSupersetOf([NSOrderedSet orderedSetWithObject:@"xyz"]));
+  assertPass(test_expect(dictionary.mutableCopy).notTo.beSupersetOf(@{ @"xyz" : @2 }));
 
   assertFail(test_expect(nil).notTo.beSupersetOf([NSArray array]), @"nil/null is not an instance of NSDictionary and does not implement -containsObject:");
   assertFail(test_expect(array).notTo.beSupersetOf(nil), @"the expected value is nil/null");


### PR DESCRIPTION
`[subset isKindOfClass:[actual class]]` method doesn't work in cases of when we compare mutable and immutable collection, e.g. NSMutableArray and NSArray.
NSMutableArray is implemented in its subclass __NSArrayM and NSArray is implemented in its subclass __NSArrayI.

In this case isKindOfClass will return NO, because __NSArrayM is subclass of NSArray but not of __NSArrayI.