### PR TITLE
The rake clean and build tasks should work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@
 xcuserdata
 .idea
 build/
+Products/
 *.pbxuser
 *.mode1v3
-
-products/*.h
-products/*.a
-products/LICENSE
-products/README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: objective-c
 osx_image: xcode611
-script: Tests/Support/objc-build-scripts/cibuild
+
+script:
+  - rake clean
+  - Tests/Support/objc-build-scripts/cibuild

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ def lipo(bin1, bin2, output)
 end
 
 def clean(scheme)
-  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} clean"
+  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} clean -derivedDataPath build -SYMROOT=build"
 end
 
 def puts_green(str)

--- a/Rakefile
+++ b/Rakefile
@@ -35,10 +35,6 @@ def lipo(bin1, bin2, output)
   execute "xcrun lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
 end
 
-def clean(scheme)
-  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} clean -derivedDataPath build -SYMROOT=build"
-end
-
 def puts_green(str)
   puts "#{GREEN_COLOR}#{str}#{NO_COLOR}"
 end
@@ -51,8 +47,9 @@ end
 desc 'clean'
 task :clean do |t|
   puts_green '=== CLEAN ==='
-  clean('Expecta')
-  clean('Expecta-iOS')
+  execute 'rm -rf build'
+  execute 'rm -rf Expecta/build'
+  execute 'rm -rf Expecta/Products'
 end
 
 desc 'build'

--- a/Rakefile
+++ b/Rakefile
@@ -18,8 +18,11 @@ def test(scheme)
 end
 
 def build(scheme, sdk, product)
+  build_dir = CONFIGURATION
+  if sdk != 'macosx'
+    build_dir = "#{CONFIGURATION}-#{sdk}"
+  end
   execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION}"
-  build_dir = "#{CONFIGURATION}#{sdk == 'macosx' ? '' : "-#{sdk}"}"
   "Expecta/build/#{build_dir}/#{product}"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ def build(scheme, sdk, product)
     end
   end
   execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} #{destination} -configuration #{CONFIGURATION} | xcpretty -c && exit ${PIPESTATUS[0]}"
-  "Expecta/build/#{build_dir}/#{product}"
+  "build/#{build_dir}/#{product}"
 end
 
 def build_framework(scheme, sdk)

--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,20 @@ def test(scheme)
   execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
 end
 
+def ios_simulator_destination
+  "-destination 'platform=iOS Simulator,name=iPhone 5,OS=latest'"
+end
+
 def build(scheme, sdk, product)
+  destination = ''
   build_dir = CONFIGURATION
   if sdk != 'macosx'
     build_dir = "#{CONFIGURATION}-#{sdk}"
+    if sdk == 'iphonesimulator'
+      destination = ios_simulator_destination
+    end
   end
-  execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION}"
+  execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} #{destination} -configuration #{CONFIGURATION} | xcpretty -c && exit ${PIPESTATUS[0]}"
   "Expecta/build/#{build_dir}/#{product}"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,6 @@ task :build => :clean do |t|
   ios_sim_static_lib = build_static_lib('libExpecta-iOS', 'iphonesimulator')
   ios_static_lib     = build_static_lib('libExpecta-iOS', 'iphoneos')
 
-  osx_build_path = Pathname.new(osx_framework).parent.to_s
   ios_build_path = Pathname.new(ios_framework).parent.to_s
   ios_univ_build_path = "Expecta/build/#{CONFIGURATION}-ios-universal"
 
@@ -108,7 +107,7 @@ task :build => :clean do |t|
   execute "cp -a #{osx_static_lib} Products/osx"
   execute "cp -a #{ios_univ_framework} Products/ios"
   execute "cp -a #{ios_univ_static_lib} Products/ios"
-  execute "cp -a #{osx_build_path}/usr/local/include/* Products"
+  execute "cp -a #{osx_framework}/Headers/* Products"
   puts "\n** BUILD SUCCEEDED **"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,10 @@ def ios_simulator_destination
   "-destination 'platform=iOS Simulator,name=iPhone 5,OS=latest'"
 end
 
+def code_signing_identity
+  ENV['EXP_CODE_SIGNING_IDENTITY'] || 'iPhone Developer'
+end
+
 def build(scheme, sdk, product)
   destination = ''
   build_dir = CONFIGURATION
@@ -94,7 +98,7 @@ task :build => :clean do |t|
   lipo(ios_static_lib, ios_sim_static_lib, ios_univ_static_lib)
 
   puts_green "\n=== CODESIGN iOS FRAMEWORK ==="
-  execute "xcrun codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
+  execute "xcrun codesign --force --sign \"#{code_signing_identity}\" '#{ios_univ_framework}'"
 
   puts_green "\n=== COPY PRODUCTS ==="
   execute "yes | rm -rf Products"

--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,11 @@ def execute(command, stdout=nil)
 end
 
 def test(scheme)
-  execute "xcodebuild -project #{PROJECT} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
+  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
 end
 
 def build(scheme, sdk, product)
-  execute "xcodebuild -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION} SYMROOT=build"
+  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION} SYMROOT=build"
   build_dir = "#{CONFIGURATION}#{sdk == 'macosx' ? '' : "-#{sdk}"}"
   "Expecta/build/#{build_dir}/#{product}"
 end
@@ -32,11 +32,11 @@ def build_static_lib(scheme, sdk)
 end
 
 def lipo(bin1, bin2, output)
-  execute "lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
+  execute "xcrun lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
 end
 
 def clean(scheme)
-  execute "xcodebuild -project #{PROJECT} -scheme #{scheme} clean"
+  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} clean"
 end
 
 def puts_green(str)
@@ -45,7 +45,7 @@ end
 
 desc 'Run tests'
 task :test do |t|
-  execute "xcodebuild test -project #{PROJECT} -scheme Expecta"
+  execute "xcrun xcodebuild test -project #{PROJECT} -scheme Expecta"
 end
 
 desc 'clean'
@@ -86,7 +86,7 @@ task :build => :clean do |t|
   lipo(ios_static_lib, ios_sim_static_lib, ios_univ_static_lib)
 
   puts_green "\n=== CODESIGN iOS FRAMEWORK ==="
-  execute "/usr/bin/codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
+  execute "xcrun codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
 
   puts_green "\n=== COPY PRODUCTS ==="
   execute "yes | rm -rf Products"

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ def test(scheme)
 end
 
 def build(scheme, sdk, product)
-  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION} SYMROOT=build"
+  execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION}"
   build_dir = "#{CONFIGURATION}#{sdk == 'macosx' ? '' : "-#{sdk}"}"
   "Expecta/build/#{build_dir}/#{product}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ def execute(command, stdout=nil)
 end
 
 def test(scheme)
-  execute "xcrun xcodebuild -project #{PROJECT} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
+  execute "xcrun xcodebuild -derivedDataPath build SYMROOT=build -project #{PROJECT} -scheme #{scheme} -configuration #{CONFIGURATION} test | xcpretty -c && exit ${PIPESTATUS[0]}"
 end
 
 def ios_simulator_destination


### PR DESCRIPTION
### Motivation

`$ rake` does not work out of the box.  

Ordinarily, I would not make such a broad PR.  However, there were so many problems, breaking the commits up into small PR would have led to merge conflicts.

### TL;DR

1. Run Xcode tools in the context of `xcrun`.
2. Confine build products to `build` directory with `-derivedDataPath build SYMROOT=build`.
3. iOS Simulator builds require a `-destination`.
4. Remove ResourceRules.plist from code signing step.
5. Control code signing identity with a Unix environment variable.

#### Code signing

I am not sure a code-signing step is necessary on the iOS framework.  It tried to use the resulting framework in a project and it did not work.

1. Missing headers in the Expecta.h umbrella
2. The framework was not able to be loaded into the app.

I believe the problem is that framework is not structured like an Objective-C framework and behaves more like dylib (which would need to be signed).  Addressing this problem is beyond the scope of this PR.  I recommend:

1. removing the code signing step; it is unnecessary unless you want/need a dylib.
2. create a framework that looks and feels more like an Objective-C framework.  I can see that OCHamcrest and OCMockito are already doing this.

#### Travis CI

I wanted to put the `build` task into Travis CI, but could not because it requires code signing.  I added the `clean` task because it was failing.

### Implementation Notes

These are the steps I touch to get the rake build task to work.

##### rake clean
```
$ git clone --recursive <snip>
$ cd expecta
$ rake clean
Running xcrun xcodebuild -project Expecta.xcodeproj -scheme Expecta-iOS clean...
xcodebuild: error: Failed to build project Expecta with scheme Expecta-iOS.
	Reason: The run destination iPad 2 is not valid for Running the scheme 'Expecta-iOS'.
```

This problem can be solved by confining `xcodebuild` products to the `build` directory using:

* `SYMROOT=build`
* `-derivedDataPath build`

and running `rm -rf` on:

* `./build`
* `./Expecta/build`
* `./Products`  <== this was not being cleaned

##### rake build

If you disable `clean` in the build task, you find:

```
$ rake build
xcodebuild: error: Failed to build project Expecta with scheme Expecta-iOS.
	Reason: The run destination iPad 2 is not valid for Running the scheme 'Expecta-iOS'.
```

##### missing directories

When the two errors mentioned above are cleared, you find:

```
$ rake
=== GENERATE UNIVERSAL iOS BINARY (Device/Simulator) ===
Running mkdir -p 'Expecta/build/Release-ios-universal'...
Running cp -a 'Expecta/build/Release-iphoneos/Expecta.framework' 'Expecta/build/Release-ios-universal'...
cp: Expecta/build/Release-iphoneos/Expecta.framework: No such file or directory
```

The problem is here is that the `build` method is creating intermediate products in the `build` directory, but returning a path to `Expecta/build`.  If I believe the intended behavior is stage non-universal products in `build` and combine them with `lipo` in the `Expecta/build` directory.

##### Multiple Code Signing Identities

If `codesign` matches multiple identities for `iPhone Developer` the code- singing step will fail with an ambiguous match.

```
=== CODESIGN iOS FRAMEWORK ===
Running xcrun codesign --force --sign iPhone Developer <snip>
iPhone: ambiguous (matches "iPhone Distribution: XXXXXX" and 
                           "iPhone Developer: Some Developer (8<snip>Z)" 
                   in /<snip>/login.keychain)
rake aborted!
** BUILD FAILED **
```

Added an environment variable to allow developers control the signing identity.

```
$ EXP_CODE_SIGNING_IDENTITY="iPhone Developer: Some Dev (8<snip>F)" rake
```

##### No ResourceRules.plist during codesign

```
'/ResourceRules.plist 'Expecta/build/Release-ios-universal/Expecta.framework'...
Warning: --resource-rules has been deprecated in Mac OS X >= 10.10!
Expecta/build/Release-ios-universal/Expecta.framework/ResourceRules.plist: cannot read resources
rake aborted!
** BUILD FAILED **
```

I am going out on a limb here, but after inspecting the ResourceRules.plist from the Specta project, I don't think these are necessary.  I could be very very wrong.  Cleared this by removing ResourceRules.plist from the code-sign step.

##### Copying .h files from wrong directory

```
=== COPY PRODUCTS ===
<snip>
Running cp -a build/Release/usr/local/include/* Products...
cp: build/Release/usr/local/include/*: No such file or directory
rake aborted!
```

I decided to copy the .h files from the MacOS framework.  I am not sure if this is correct or not.
