### PR TITLE
Adds an expect_fail(@"message") dsl attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 Next
 ======
-Fix potential selector conflicts [paulsamuels]
+
+v0.4.0
+======
+
+* Adds `failure` syntax to force a test fail [orta]
+* Fix potential selector conflicts [paulsamuels]
 
 v0.3.2
 ======
+
 * Adds support for Xcode/Apple LLVM 5.1, which means turning off Garbage Collection support [tonyarnold]
 * Raises minimum deployment targets to iOS 5.x and OS X 10.7 [tonyarnold]
 * Renamed `postNotification` to `notify` (with backwards compatability [gfontenot]

--- a/Expecta/Expecta.h
+++ b/Expecta/Expecta.h
@@ -12,4 +12,4 @@ FOUNDATION_EXPORT const unsigned char ExpectaVersionString[];
 
 // Enable shorthand by default
 #define expect(...) EXP_expect((__VA_ARGS__))
-#define expect_fail(...) EXP_expect_fail((__VA_ARGS__))
+#define failure(...) EXP_failure((__VA_ARGS__))

--- a/Expecta/Expecta.h
+++ b/Expecta/Expecta.h
@@ -12,3 +12,4 @@ FOUNDATION_EXPORT const unsigned char ExpectaVersionString[];
 
 // Enable shorthand by default
 #define expect(...) EXP_expect((__VA_ARGS__))
+#define expect_fail(...) EXP_expect_fail((__VA_ARGS__))

--- a/Expecta/ExpectaObject.h
+++ b/Expecta/ExpectaObject.h
@@ -7,7 +7,7 @@
 #define EXPMatcherImplementationEnd _EXPMatcherImplementationEnd
 #define EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments) _EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments)
 
-#define EXP_expect_fail(message) EXPFail(self, __LINE__, __FILE__, message)
+#define EXP_failure(message) EXPFail(self, __LINE__, __FILE__, message)
 
 
 @interface Expecta : NSObject

--- a/Expecta/ExpectaObject.h
+++ b/Expecta/ExpectaObject.h
@@ -7,6 +7,9 @@
 #define EXPMatcherImplementationEnd _EXPMatcherImplementationEnd
 #define EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments) _EXPMatcherAliasImplementation(newMatcherName, oldMatcherName, matcherArguments)
 
+#define EXP_expect_fail(message) EXPFail(self, __LINE__, __FILE__, message)
+
+
 @interface Expecta : NSObject
 
 + (NSTimeInterval)asynchronousTestTimeout;

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You can setup Expecta using [Carthage](https://github.com/Carthage/Carthage), [C
 
 > `expect(x).to.endWith(y);` passes if an instance of NSString, NSArray, or NSOrderedSet `x` ends with `y`.
 
+
 ## Inverting Matchers
 
 Every matcher's criteria can be inverted by prepending `.notTo` or `.toNot`:
@@ -169,6 +170,13 @@ describe(@"Foo", ^{
   });
 });
 ```
+
+## Forced Failing
+
+You can fail a test by using the `failure` attribute. This can be used to test branching.
+
+> `failure(@"This should not happen");` outright fails a test.
+
 
 ## Writing New Matchers
 

--- a/Tests/EXPFailTest.m
+++ b/Tests/EXPFailTest.m
@@ -1,6 +1,39 @@
 #import "TestHelper.h"
 #import "EXPFailTest.h"
 
+@interface EXPExpectFailTest : XCTestCase
+@property (nonatomic, copy) NSString *fileName;
+@property (nonatomic, copy) NSString *errorDescription;
+@property (assign) NSUInteger lineNumber;
+@end
+
+@implementation EXPExpectFailTest
+
+// This test is dependent on the LOC with the expect_fail on
+static NSInteger EXPFailTestLine = 28;
+
+- (void)recordFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected
+{
+    if (lineNumber != EXPFailTestLine) {
+        [super recordFailureWithDescription:description inFile:filePath atLine:lineNumber expected:expected];
+    } else {
+        self.fileName = filePath;
+        self.lineNumber = lineNumber;
+        self.errorDescription = description;
+    }
+}
+
+- (void)test_ExpectFailToFail
+{
+    expect_fail(@"Expect Fail to Fail");
+
+    assertEqualObjects(self.errorDescription, @"Expect Fail to Fail");
+    assertTrue([self.fileName hasSuffix:@"EXPFailTest.m"]);
+    assertEqualObjects(@(self.lineNumber), @(EXPFailTestLine));
+}
+
+@end
+
 @implementation TestCaseClassWithoutFailMethod
 
 - (void)fail {
@@ -75,5 +108,6 @@
     assertEquals(testCase.expected, NO);
     [testCase release];
 }
+
 
 @end

--- a/Tests/EXPFailTest.m
+++ b/Tests/EXPFailTest.m
@@ -9,7 +9,7 @@
 
 @implementation EXPExpectFailTest
 
-// This test is dependent on the LOC with the expect_fail on
+// This test is dependent on the LOC with the failure on
 static NSInteger EXPFailTestLine = 28;
 
 - (void)recordFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected
@@ -25,7 +25,7 @@ static NSInteger EXPFailTestLine = 28;
 
 - (void)test_ExpectFailToFail
 {
-    expect_fail(@"Expect Fail to Fail");
+    failure(@"Expect Fail to Fail");
 
     assertEqualObjects(self.errorDescription, @"Expect Fail to Fail");
     assertTrue([self.fileName hasSuffix:@"EXPFailTest.m"]);


### PR DESCRIPTION
This PR adds the ability to explicitly fail a test via a function ala `expect_fail(@"shouldn't do this")`. I think this addresses https://github.com/specta/expecta/issues/96 - opening for discussion before updating README/CHANGELOG etc

opinions?