### PR TITLE
Fix leaking block

### DIFF
--- a/Expecta/EXPExpect.m
+++ b/Expecta/EXPExpect.m
@@ -42,6 +42,7 @@
 
 - (void)dealloc
 {
+  [_actualBlock release];
   _actualBlock = nil;
   [super dealloc];
 }


### PR DESCRIPTION
The `_actualBlock` value is never released in `dealloc` meaning everything captured in `expect()` is leaked.