### PR TITLE
postNotificationTest: Remove deprecated GCD func

### DIFF
--- a/Tests/Matchers/EXPMatchers+postNotificationTest.m
+++ b/Tests/Matchers/EXPMatchers+postNotificationTest.m
@@ -55,7 +55,7 @@
   }).to.notify([NSNotification notificationWithName:@"testNotification1" object:object]));
 
   assertPass(test_expect(^{
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_current_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
       [[NSNotificationCenter defaultCenter] postNotificationName:@"NotificationName" object:nil];
     });
   }).will.postNotification(@"NotificationName"));


### PR DESCRIPTION
`dispatch_get_current_queue()` is deprecated as of OS X 10.9. Luckily,
we know XCTest test cases are always run serially on the main queue, so
we can replace this call with a simple `dispatch_get_main_queue()`
instead. This fixes a compiler warning.