### PR TITLE
Avoid holding matcher in the thread dictionary after matching.

### DIFF
--- a/Expecta/ExpectaSupport.h
+++ b/Expecta/ExpectaSupport.h
@@ -53,6 +53,7 @@ EXPFixCategoriesBug(EXPMatcher##matcherName##Matcher); \
 #define _EXPMatcherImplementationEnd \
     } \
     [self applyMatcher:matcher to:&actual]; \
+    [[[NSThread currentThread] threadDictionary] removeObjectForKey:@"EXP_currentMatcher"]; \
   } copy]; \
   _EXP_release(matcher); \
   return _EXP_autorelease(matcherBlock); \

--- a/Tests/ExpectationTest.m
+++ b/Tests/ExpectationTest.m
@@ -8,6 +8,34 @@
 }
 @end
 
+@interface ExpectedObject : NSObject
+
++ (NSUInteger)instanceCount;
+
+@end
+
+@implementation ExpectedObject
+
+- (instancetype)init {
+  if (self = [super init]) {
+    ++_instanceCount;
+  }
+  return self;
+}
+
+- (void)dealloc {
+  --_instanceCount;
+  [super dealloc];
+}
+
+static NSUInteger _instanceCount;
+
++ (NSUInteger)instanceCount {
+  return _instanceCount;
+}
+
+@end
+
 @implementation ExpectationTest
 
 - (void)test_expect {
@@ -196,6 +224,15 @@
   expect(yesBool).to.equal(yesBOOL);
   expect(yesBOOL).to.equal(yesInt);
   expect(yesInt).to.equal(yesNSNum);
+}
+
+- (void)test_expect_memory_management {
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  ExpectedObject *object = [[[ExpectedObject alloc] init] autorelease];
+  expect(object).to.equal(object);
+  [pool drain];
+
+  assertEquals([ExpectedObject instanceCount], 0);
 }
 
 @end


### PR DESCRIPTION
This solves issues where an object that is given to the matcher (the
expected object) is not released until a second expect() is called which
replaces the previous matcher in the thread dictionary.