### PR TITLE
Assign actual value to a strong variable in EXP_expect.

### DIFF
--- a/Expecta/ExpectaObject.h
+++ b/Expecta/ExpectaObject.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 
 #define EXPObjectify(value) _EXPObjectify(@encode(__typeof__((value))), (value))
-#define EXP_expect(actual) _EXP_expect(self, __LINE__, __FILE__, ^id{ return EXPObjectify((actual)); })
+#define EXP_expect(actual) _EXP_expect(self, __LINE__, __FILE__, ^id{ __typeof__((actual)) strongActual = (actual); return EXPObjectify(strongActual); })
 #define EXPMatcherInterface(matcherName, matcherArguments) _EXPMatcherInterface(matcherName, matcherArguments)
 #define EXPMatcherImplementationBegin(matcherName, matcherArguments) _EXPMatcherImplementationBegin(matcherName, matcherArguments)
 #define EXPMatcherImplementationEnd _EXPMatcherImplementationEnd


### PR DESCRIPTION
Weak values are accessed multiple times in EXP_expect, and may be set to nil in the middle of expectation.

This is revealed by expecting a weak value and turning on the CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK property in the build settings.