### PR TITLE
Xcode 9 - Fix warning "This function declaration is not a prototype"

### DIFF
--- a/Expecta/EXPDefines.h
+++ b/Expecta/EXPDefines.h
@@ -9,9 +9,9 @@
 #ifndef Expecta_EXPDefines_h
 #define Expecta_EXPDefines_h
 
-typedef void (^EXPBasicBlock)();
-typedef id (^EXPIdBlock)();
-typedef BOOL (^EXPBoolBlock)();
-typedef NSString *(^EXPStringBlock)();
+typedef void (^EXPBasicBlock)(void);
+typedef id (^EXPIdBlock)(void);
+typedef BOOL (^EXPBoolBlock)(void);
+typedef NSString *(^EXPStringBlock)(void);
 
 #endif


### PR DESCRIPTION
![warnings](https://user-images.githubusercontent.com/604657/27733813-6b51c6fc-5d98-11e7-8f50-7671d2f2b956.png)
