### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Expecta is framework-agnostic: it works well with XCTest and XCTest-compatible t
 
 > `expect(x).to.respondTo(y);` passes if `x` responds to the selector `y`.
 
-> `expect(^{ /* code */ }).to.notify(@"NotificationName");` passes if a given block of code generates an NSNotification amed `NotificationName`.
+> `expect(^{ /* code */ }).to.notify(@"NotificationName");` passes if a given block of code generates an NSNotification named `NotificationName`.
 
 > `expect(^{ /* code */ }).to.notify(notification);` passes if a given block of code generates an NSNotification equal to the passed `notification`.
 


### PR DESCRIPTION
Notification matcher description had a typo in it which has been fixed.